### PR TITLE
Update FAQ.cs

### DIFF
--- a/src/OnePlusBot/Modules/FAQ.cs
+++ b/src/OnePlusBot/Modules/FAQ.cs
@@ -153,7 +153,7 @@ namespace OnePlusBot.Modules
                         }
                         else
                         {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("For all device APKs, please visit: <https://www.celsoazevedo.com/files/android/google-camera>"));
+                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Please refer to your device channel"));
                         }
                         break;
                     case "edl":
@@ -192,11 +192,19 @@ namespace OnePlusBot.Modules
                                              "Place the relevant zip at the root of the system storage of your phone and use local update feature (Settings --> System --> System Updates --> click on the wheel) to update to Android Q dev preview." + Environment.NewLine +
                                              "If you want to rollback to stable release of Android Pie, use again local update feature with these zips <https://oxygenos.oneplus.net/fulldowngrade_wipe_MSM_17819_181025_2315_user_MP1_release.zip> (for OP6) / https://oxygenos.oneplus.net/Fulldowngrade_wipe_18801_181024_2027_user_MP2_release.zip (for OP6T)" + Environment.NewLine +
                                               Environment.NewLine +
-                                             "**WARN**: T-Mobile OP6T converted users can flash Q Preview but will have to use MSM tool to recover their device if they wish to downgrade as the rollback zip provided by OnePlus will lead to a device mismatch according to reports on XDA forums (sources <https://forum.xda-developers.com/showpost.php?p=79482702&postcount=2295> and <https://forum.xda-developers.com/showpost.php?p=79483602&postcount=57> )"));
+                                             "**WARNING**: T-Mobile OP6T converted users can flash Q Preview but will have to use MSM tool to recover their device if they wish to downgrade as the rollback zip provided by OnePlus will lead to a device mismatch according to reports on XDA forums (sources <https://forum.xda-developers.com/showpost.php?p=79482702&postcount=2295> and <https://forum.xda-developers.com/showpost.php?p=79483602&postcount=57> )"));
+                        }
+                        break;
+                    case "softwaremaintenanceschedule":
+                    case "updateschedule":
+                    case "updatewhen":
+                        {
+                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Oneplus software maintenance schedule is described at <https://forums.oneplus.com/threads/oneplus-software-maintenance-schedule.862347/>"));
+                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithImageUrl("https://forums.oneplus.com/attachments/806308"));
                         }
                         break;
                     default:
-                        await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Supported commands are: bluspark, googlecamera, oxygenos, unbrick, edl, magisk, root, qualcommdiagnostics, smt, qpreview"));
+                        await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Supported FAQ commands are: bluspark, googlecamera, oxygenos, unbrick, edl, magisk, root, qualcommdiagnostics, smt, qpreview, updateschedule"));
                         break;
                 }
             }
@@ -204,6 +212,11 @@ namespace OnePlusBot.Modules
             {
                 await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription(ex.Message));
             }
+        }
+
+        private object EmbedImage()
+        {
+            throw new NotImplementedException();
         }
     }
 }


### PR DESCRIPTION
Change "WARN" to "WARNING" following feedback at https://discordapp.com/channels/378969558574432277/420342647035658262/576726913813315585

Add OnePlus software maintenance schedule to FAQ

Replace gcam link (which was introduced at https://github.com/Rithari/OnePlusBot/blame/7e269b9fd0cd3c03792a9e88e9695cdbacb10837/src/OnePlusBot/Modules/FAQ.cs#L154 ) by instruction to refer to relevant device channel as this command is for mirrors of OxygenOS and not for Gcam