### PR TITLE
Split mute roles into two

### DIFF
--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -26,14 +26,30 @@ namespace OnePlusBot.Helpers
         }
         public static async Task MuteUser(IGuildUser user)
         {
-            var muteRole = user.Guild.GetRole(Global.Roles["muted"]);
+            // will be replaced with a better handling in the future
+            if(!Global.Roles.ContainsKey("voicemuted") || !Global.Roles.ContainsKey("textmuted"))
+            {
+                return;
+            }
+            var muteRole = user.Guild.GetRole(Global.Roles["voicemuted"]);
+            await user.AddRoleAsync(muteRole);
+
+            muteRole = user.Guild.GetRole(Global.Roles["textmuted"]);
             await user.AddRoleAsync(muteRole);
         }
 
 
         public static async Task UnMuteUser(IGuildUser user)
         {
-            var muteRole = user.Guild.GetRole(Global.Roles["muted"]);
+            // will be replaced with a better handling in the future
+            if(!Global.Roles.ContainsKey("voicemuted") || !Global.Roles.ContainsKey("textmuted"))
+            {
+                return;
+            }
+            var muteRole = user.Guild.GetRole(Global.Roles["voicemuted"]);
+            await user.RemoveRoleAsync(muteRole);
+
+            muteRole = user.Guild.GetRole(Global.Roles["textmuted"]);
             await user.RemoveRoleAsync(muteRole);
         }
 

--- a/src/OnePlusBot/Modules/Mute.cs
+++ b/src/OnePlusBot/Modules/Mute.cs
@@ -104,10 +104,16 @@ namespace OnePlusBot.Modules
             var author = Context.Message.Author;
 
             var guild = Context.Guild;
-            var mutedRoleName = "muted";
+            var mutedRoleName = "textmuted";
             if(!Global.Roles.ContainsKey(mutedRoleName))
             {
-                return CustomResult.FromError("Mute role has not been configured.");
+                return CustomResult.FromError("Text mute role has not been configured.");
+            }
+
+            mutedRoleName = "voicemuted";
+            if(!Global.Roles.ContainsKey(mutedRoleName))
+            {
+                return CustomResult.FromError("Voice mute role has not been configured.");
             }
 
             await Extensions.MuteUser(user);


### PR DESCRIPTION
Mute roles are split into two roles: voice and text, therefore we need to apply/remove both. 