### PR TITLE
Exception handling for mute & joinlog fix

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -47,7 +47,7 @@ namespace OnePlusBot.Base
         private async Task OnUserLeft(SocketGuildUser socketGuildUser)
         {
             var modlog = socketGuildUser.Guild.GetTextChannel(Global.Channels["joinlog"]);
-            await modlog.SendMessageAsync(socketGuildUser?.Mention ?? socketGuildUser.Username + '#' + socketGuildUser.Discriminator + " left the guild");
+            await modlog.SendMessageAsync((socketGuildUser?.Mention ?? socketGuildUser.Username + '#' + socketGuildUser.Discriminator) + " left the guild");
         }
 
         private async Task OnuserUserJoined(SocketGuildUser socketGuildUser)

--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -61,12 +61,16 @@ namespace OnePlusBot.Base
           await UnMuteUser(userId, muteId);
         }
 
-        public static async Task UnMuteUser(ulong userId, ulong muteId)
+        public static async Task<CustomResult> UnMuteUser(ulong userId, ulong muteId)
         {
           var bot = Global.Bot;
           var guild = bot.GetGuild(Global.ServerID);
           var user = guild.GetUser(userId);
-          await OnePlusBot.Helpers.Extensions.UnMuteUser(user);
+          var result = await OnePlusBot.Helpers.Extensions.UnMuteUser(user);
+          if(!result.IsSuccess)
+          {
+            return result;
+          }
           using (var db = new Database())
           {
             if(muteId == UInt64.MaxValue)
@@ -84,7 +88,6 @@ namespace OnePlusBot.Base
               if(!muteObj.MuteEnded)
               {
                 muteObj.MuteEnded = true;
-                // TODO only send the notice, if the unmuting was caused by a timer? no?
                 var noticeEmbed = new EmbedBuilder();
                 noticeEmbed.Color = Color.LightOrange;
                 noticeEmbed.Title = "User has been unmuted!";
@@ -98,6 +101,7 @@ namespace OnePlusBot.Base
             }
             db.SaveChanges();
           }
+          return result;
         }
       }
 }

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -24,33 +24,35 @@ namespace OnePlusBot.Helpers
             
             return new Uri(usr.GetAvatarUrl(ImageFormat.Auto, size));
         }
-        public static async Task MuteUser(IGuildUser user)
+        public static async Task<CustomResult> MuteUser(IGuildUser user)
         {
             // will be replaced with a better handling in the future
             if(!Global.Roles.ContainsKey("voicemuted") || !Global.Roles.ContainsKey("textmuted"))
             {
-                return;
+                return CustomResult.FromError("Configure the voicemuted and textmuted roles correctly. Check your Db!");
             }
             var muteRole = user.Guild.GetRole(Global.Roles["voicemuted"]);
             await user.AddRoleAsync(muteRole);
 
             muteRole = user.Guild.GetRole(Global.Roles["textmuted"]);
             await user.AddRoleAsync(muteRole);
+            return CustomResult.FromSuccess();
         }
 
 
-        public static async Task UnMuteUser(IGuildUser user)
+        public static async Task<CustomResult> UnMuteUser(IGuildUser user)
         {
             // will be replaced with a better handling in the future
             if(!Global.Roles.ContainsKey("voicemuted") || !Global.Roles.ContainsKey("textmuted"))
             {
-                return;
+                return CustomResult.FromError("Configure the voicemuted and textmuted roles correctly. Check your Db!");
             }
             var muteRole = user.Guild.GetRole(Global.Roles["voicemuted"]);
             await user.RemoveRoleAsync(muteRole);
 
             muteRole = user.Guild.GetRole(Global.Roles["textmuted"]);
             await user.RemoveRoleAsync(muteRole);
+            return CustomResult.FromSuccess();
         }
 
         public static String FormatUserName(IUser user)

--- a/src/OnePlusBot/Modules/Mute.cs
+++ b/src/OnePlusBot/Modules/Mute.cs
@@ -173,8 +173,7 @@ namespace OnePlusBot.Modules
         ]
         public async Task<RuntimeResult> UnMuteUser(IGuildUser user)
         {
-            await MuteTimerManager.UnMuteUser(user.Id, ulong.MaxValue);
-            return CustomResult.FromSuccess();
+            return await MuteTimerManager.UnMuteUser(user.Id, ulong.MaxValue);
         }
 
     }


### PR DESCRIPTION
The UnMute method returned a normal task, without a type, so we had no idea, whether or not it was successful. This was not a problem for Mute, because there has been a check before the method.
With this changes the CustomResult is used to indicate whether or not the UnMute/Mute was successful and fixes #78 .
This changes also include a fix to the mention of users in joinlog.

How to deploy:
build and restart bot.