### PR TITLE
Added handling for banned words

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -128,12 +128,13 @@ namespace OnePlusBot.Base
 
             var bannedWords = Global.BannedWords;
             var messageSplit = message.Content.Split(" ");
+            var loweredMsgParts = messageSplit.ToList().ConvertAll(d => d.ToLower());
 
-            for (int x = 0; x < messageSplit.Length; x++)
+            for (int x = 0; x < loweredMsgParts.Count; x++)
             {
                 for (int y = 0; y < bannedWords.Count; y++)
                 {
-                    if(messageSplit[x].Contains(bannedWords[y]))
+                    if(loweredMsgParts[x].Contains(bannedWords[y]))
                     {
                        await message.DeleteAsync();
                        return;
@@ -463,12 +464,13 @@ namespace OnePlusBot.Base
 
             var bannedWords = Global.BannedWords;
             var messageSplit = message.Content.Split(" ");
+            var loweredMsgParts = messageSplit.ToList().ConvertAll(d => d.ToLower());
 
-            for (int x = 0; x < messageSplit.Length; x++)
+            for (int x = 0; x < loweredMsgParts.Count; x++)
             {
                 for (int y = 0; y < bannedWords.Count; y++)
                 {
-                    if(messageSplit[x].Contains(bannedWords[y]))
+                    if(loweredMsgParts[x].Contains(bannedWords[y]))
                     {
                        await message.DeleteAsync();
                        return;

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -126,6 +126,21 @@ namespace OnePlusBot.Base
             if(before.Author.IsBot)
                 return;
 
+            var bannedWords = Global.BannedWords;
+            var messageSplit = message.Content.Split(" ");
+
+            for (int x = 0; x < messageSplit.Length; x++)
+            {
+                for (int y = 0; y < bannedWords.Count; y++)
+                {
+                    if(messageSplit[x].Contains(bannedWords[y]))
+                    {
+                       await message.DeleteAsync();
+                       return;
+                    }
+                }
+            }
+               
             var embed = new EmbedBuilder
             {
                 Color = Color.Blue,
@@ -446,6 +461,21 @@ namespace OnePlusBot.Base
                CacheAttachment(message);
             }
 
+            var bannedWords = Global.BannedWords;
+            var messageSplit = message.Content.Split(" ");
+
+            for (int x = 0; x < messageSplit.Length; x++)
+            {
+                for (int y = 0; y < bannedWords.Count; y++)
+                {
+                    if(messageSplit[x].Contains(bannedWords[y]))
+                    {
+                       await message.DeleteAsync();
+                       return;
+                    }
+                }
+            }
+               
             var channelId = message.Channel.Id;
 
             if (channelId == Global.Channels["setups"])

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using System.Collections;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Discord;
@@ -60,6 +61,8 @@ namespace OnePlusBot.Base
             }
         }
 
+       public static List<string> BannedWords { get; }
+
         static Global()
         {
             Random = new Random();
@@ -82,6 +85,14 @@ namespace OnePlusBot.Base
                 MessageId = db.PersistentData
                     .First(x => x.Name == "rolemanager_message_id")
                     .Value;
+
+                BannedWords = new List<string>();
+                if(db.BannedWords.Any()){
+                    foreach(var word in db.BannedWords){
+                        BannedWords.Add(word.Word);
+                    }
+                }
+                
             }
         }
 

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -11,6 +11,8 @@ namespace OnePlusBot.Data
         public DbSet<Channel> Channels { get; set; }
         public DbSet<AuthToken> AuthTokens { get; set; }
         public DbSet<PersistentData> PersistentData { get; set; }
+
+        public DbSet<BannedWord> BannedWords { get; set; }
         public DbSet<ReportEntry> Reports { get; set; }
         public DbSet<ReferralCode> ReferralCodes { get; set; }
         public DbSet<WarnEntry> Warnings { get; set; }

--- a/src/OnePlusBot/Data/Models/BannedWord.cs
+++ b/src/OnePlusBot/Data/Models/BannedWord.cs
@@ -1,0 +1,17 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("BannedWords")]
+    public class BannedWord
+    {
+        [Key]
+        [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public uint ID { get; set; }
+        
+        [Column("word")]
+        public string Word { get; set; }
+    }
+}


### PR DESCRIPTION
This PR will cause the OnMessageUpdated and OnMessageReceived handler to automatically remove messages, if it finds a string in them. 
These strings are read from a database table at startup. It will effectively iterate over all banned words and remove the message if it finds any in the message content.

If no words are configured, this will not change any behavior.