### PR TITLE
Refactored wordlist filter to reporting system

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -126,14 +126,17 @@ namespace OnePlusBot.Base
             if(before.Author.IsBot)
                 return;
 
-            var profanityChecks = Global.ProfanityChecks;
-            var lowerMessage = message.Content.ToLower();
-            foreach (var regexObj in profanityChecks)
-            {
-                if(regexObj.Match(lowerMessage).Success)
+            var fullChannel = Extensions.GetChannelById(message.Channel.Id);
+            if(!fullChannel.ProfanityCheckExempt){
+                var profanityChecks = Global.ProfanityChecks;
+                var lowerMessage = message.Content.ToLower();
+                foreach (var regexObj in profanityChecks)
                 {
-                    await ReportProfanity(message);
-                    break;
+                    if(regexObj.Match(lowerMessage).Success)
+                    {
+                        await ReportProfanity(message);
+                        break;
+                    }
                 }
             }
             
@@ -480,15 +483,17 @@ namespace OnePlusBot.Base
             {
                CacheAttachment(message);
             }
-
-            var profanityChecks = Global.ProfanityChecks;
-            var lowerMessage = message.Content.ToLower();
-            foreach (var regexObj in profanityChecks)
-            {
-                if(regexObj.Match(lowerMessage).Success)
+            var channel = Extensions.GetChannelById(message.Channel.Id);
+            if(!channel.ProfanityCheckExempt){
+                var profanityChecks = Global.ProfanityChecks;
+                var lowerMessage = message.Content.ToLower();
+                foreach (var regexObj in profanityChecks)
                 {
-                    await ReportProfanity(message);
-                    break;
+                    if(regexObj.Match(lowerMessage).Success)
+                    {
+                        await ReportProfanity(message);
+                        break;
+                    }
                 }
             }
                

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Discord;
 using OnePlusBot.Data;
+using OnePlusBot.Data.Models;
 using Discord.WebSocket;
 using System.Text.RegularExpressions;
 
@@ -17,6 +18,7 @@ namespace OnePlusBot.Base
         public static ulong ServerID { get; }
         public static Dictionary<string, ulong> Roles { get; }
         public static Dictionary<string, ulong> Channels { get; }
+        public static List<Channel> FullChannels {get;}
 
         public static ulong CommandExecutorId { get; set; }
         
@@ -69,9 +71,15 @@ namespace OnePlusBot.Base
             using (var db = new Database())
             {
                 Channels = new Dictionary<string, ulong>();
+                FullChannels = new List<Channel>();
                 if (db.Channels.Any())
                     foreach (var channel in db.Channels)
+                    {
                         Channels.Add(channel.Name, channel.ChannelID);
+                        FullChannels.Add(channel);
+                    }
+                       
+                        
                 
                 Roles = new Dictionary<string, ulong>();
                 if (db.Roles.Any())

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -1,10 +1,10 @@
-﻿using System.Collections;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Discord;
 using OnePlusBot.Data;
 using Discord.WebSocket;
+using System.Text.RegularExpressions;
 
 namespace OnePlusBot.Base
 {
@@ -61,7 +61,7 @@ namespace OnePlusBot.Base
             }
         }
 
-       public static List<string> BannedWords { get; }
+       public static List<Regex> ProfanityChecks { get; }
 
         static Global()
         {
@@ -86,10 +86,12 @@ namespace OnePlusBot.Base
                     .First(x => x.Name == "rolemanager_message_id")
                     .Value;
 
-                BannedWords = new List<string>();
-                if(db.BannedWords.Any()){
-                    foreach(var word in db.BannedWords){
-                        BannedWords.Add(word.Word);
+                ProfanityChecks = new List<Regex>();
+                if(db.ProfanityChecks.Any())
+                {
+                    foreach(var word in db.ProfanityChecks)
+                    {
+                        ProfanityChecks.Add(new Regex(word.Word, RegexOptions.Singleline | RegexOptions.Compiled));
                     }
                 }
                 

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -12,7 +12,7 @@ namespace OnePlusBot.Data
         public DbSet<AuthToken> AuthTokens { get; set; }
         public DbSet<PersistentData> PersistentData { get; set; }
 
-        public DbSet<BannedWord> BannedWords { get; set; }
+        public DbSet<ProfanityCheck> ProfanityChecks { get; set; }
         public DbSet<ReportEntry> Reports { get; set; }
         public DbSet<ReferralCode> ReferralCodes { get; set; }
         public DbSet<WarnEntry> Warnings { get; set; }

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -22,5 +22,8 @@ namespace OnePlusBot.Data.Models
         
         [Column("channel_type")]
         public ChannelType ChannelType { get; set; }
+
+        [Column("profanity_check_exempt")]
+        public bool ProfanityCheckExempt{ get; set;}
     }
 }

--- a/src/OnePlusBot/Data/Models/ProfanityCheck.cs
+++ b/src/OnePlusBot/Data/Models/ProfanityCheck.cs
@@ -3,15 +3,15 @@ using System.ComponentModel.DataAnnotations.Schema;
 
 namespace OnePlusBot.Data.Models
 {
-    [Table("BannedWords")]
-    public class BannedWord
+    [Table("ProfanityChecks")]
+    public class ProfanityCheck
     {
         [Key]
         [Column("id")]
         [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
         public uint ID { get; set; }
         
-        [Column("word")]
+        [Column("regex")]
         public string Word { get; set; }
     }
 }

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -59,5 +59,10 @@ namespace OnePlusBot.Helpers
         {
             return user.Username + '#' + user.Discriminator;
         }
+
+        public static String FormatUserNameDetailed(IUser user)
+        {
+            return FormatUserName(user) + " (" + user.Id +  ") ";
+        }
     }
 }

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -1,7 +1,9 @@
-﻿using System;
+﻿using System.Linq;
+using System;
 using System.Threading.Tasks;
 using Discord;
 using OnePlusBot.Base;
+using OnePlusBot.Data.Models;
 
 namespace OnePlusBot.Helpers
 {
@@ -63,6 +65,10 @@ namespace OnePlusBot.Helpers
         public static String FormatUserNameDetailed(IUser user)
         {
             return FormatUserName(user) + " (" + user.Id +  ") ";
+        }
+
+        public static Channel GetChannelById(ulong channelId){
+            return Global.FullChannels.Where(chan => chan.ChannelID == channelId).First();
         }
     }
 }

--- a/src/OnePlusBot/Modules/Owner.cs
+++ b/src/OnePlusBot/Modules/Owner.cs
@@ -131,7 +131,8 @@ namespace OnePlusBot.Modules
                     {
                         Name = newName,
                         ChannelID = channel.Id,
-                        ChannelType = ChannelType.Text
+                        ChannelType = ChannelType.Text,
+                        ProfanityCheckExempt = false
                     });
 
                     Console.WriteLine($"[DB] [Update] Added channel {channel.Name} with Name {newName} and ID {channel.Id}");


### PR DESCRIPTION
This PR request  changes the behavior of the blanket filtering, and replaces it with regex checks, resulting in a report in a configured channel. This profanity check can be disabled in the database for certain channels, if so wished.

Steps to deploy: 
-Adapt Channel table to contain check flag -> profanity_check_exempt
-Adapt BannedWords table to new structure
-Insert wished regexes in the newly changed table
-Configure the exempt channels
-Restart bot