### PR TITLE
Full information on any place where a user is mentioned

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -47,13 +47,13 @@ namespace OnePlusBot.Base
         private async Task OnUserLeft(SocketGuildUser socketGuildUser)
         {
             var modlog = socketGuildUser.Guild.GetTextChannel(Global.Channels["joinlog"]);
-            await modlog.SendMessageAsync((socketGuildUser?.Mention ?? socketGuildUser.Username + '#' + socketGuildUser.Discriminator) + " left the guild");
+            await modlog.SendMessageAsync(Extensions.FormatMentionDetailed(socketGuildUser) + "left the guild");
         }
 
         private async Task OnuserUserJoined(SocketGuildUser socketGuildUser)
         {
             var modlog = socketGuildUser.Guild.GetTextChannel(Global.Channels["joinlog"]);
-            await modlog.SendMessageAsync(socketGuildUser.Mention + " joined the guild");
+            await modlog.SendMessageAsync(Extensions.FormatMentionDetailed(socketGuildUser) + "joined the guild");
         }
 
         private async Task OnUserUnbanned(SocketUser socketUser, SocketGuild socketGuild)
@@ -400,7 +400,8 @@ namespace OnePlusBot.Base
             embed.Author = new EmbedAuthorBuilder()
                 .WithName(message.Author.Username)
                 .WithIconUrl(message.Author.GetAvatarUrl());
-            embed.Description = $"Sent by {message.Author.Mention}";
+            var safeUsername = Extensions.FormatMentionDetailed(message.Author);
+            embed.Description = $"Sent by {safeUsername}";
             
             foreach (Match match in matches)
             {
@@ -464,7 +465,7 @@ namespace OnePlusBot.Base
             builder.ThumbnailUrl = message.Author.GetAvatarUrl();
 
             const string discordUrl = "https://discordapp.com/channels/{0}/{1}/{2}";
-            builder.AddField("User in question ", Extensions.FormatUserNameDetailed(message.Author))
+            builder.AddField("User in question ", Extensions.FormatMentionDetailed(message.Author))
                 .AddField(
                     "Location of the profane message",
                     $"[#{message.Channel.Name}]({string.Format(discordUrl, guild.Id, message.Channel.Id, message.Id)})");

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -67,6 +67,10 @@ namespace OnePlusBot.Helpers
             return FormatUserName(user) + " (" + user.Id +  ") ";
         }
 
+        public static String FormatMentionDetailed(IUser user){
+            return user?.Mention + " " + FormatUserNameDetailed(user);
+        }
+
         public static Channel GetChannelById(ulong channelId){
             return Global.FullChannels.Where(chan => chan.ChannelID == channelId).DefaultIfEmpty(null).First();
         }

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -59,12 +59,12 @@ namespace OnePlusBot.Helpers
 
         public static String FormatUserName(IUser user)
         {
-            return user.Username + '#' + user.Discriminator;
+            return user?.Username + '#' + ?.Discriminator;
         }
 
         public static String FormatUserNameDetailed(IUser user)
         {
-            return FormatUserName(user) + " (" + user.Id +  ") ";
+            return FormatUserName(user) + " (" + user?.Id +  ") ";
         }
 
         public static String FormatMentionDetailed(IUser user){

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -59,7 +59,7 @@ namespace OnePlusBot.Helpers
 
         public static String FormatUserName(IUser user)
         {
-            return user?.Username + '#' + ?.Discriminator;
+            return user?.Username + '#' + user?.Discriminator;
         }
 
         public static String FormatUserNameDetailed(IUser user)

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -323,8 +323,8 @@ namespace OnePlusBot.Modules
             });
 
             const string discordUrl = "https://discordapp.com/channels/{0}/{1}/{2}";
-            builder.AddField("Warned User", user?.Mention ?? entry.WarnedUser + "(" + entry.WarnedUserID + ")")
-                .AddField("Warned by", monitor?.Mention ?? entry.WarnedBy + "(" + entry.WarnedUserID + ")")
+            builder.AddField("Warned User", Extensions.FormatMentionDetailed(user))
+                .AddField("Warned by", Extensions.FormatMentionDetailed(monitor))
                 .AddField(
                     "Location of the incident",
                     $"[#{Context.Message.Channel.Name}]({string.Format(discordUrl, Context.Guild.Id, Context.Channel.Id, Context.Message.Id)})")
@@ -419,21 +419,23 @@ namespace OnePlusBot.Modules
                 var warnedBy = Context.Guild.GetUser(warning.WarnedByID);
                 if (_user != null)
                 {
-
+                    var warnedByUserSafe = Extensions.FormatMentionDetailed(warnedBy);
                     embed.AddField(new EmbedFieldBuilder()
                         .WithName("Warning #" + counter + " (" + warning.ID + ")")
                         .WithValue($"**Reason**: {warning.Reason}\n" +
-                                   $"**Warned by**: {warnedBy?.Mention ?? warning.WarnedBy}\n" + 
+                                   $"**Warned by**: {warnedByUserSafe}\n" + 
                                    $"*{warning.Date.ToString("dd/M/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}*"));
                 }
                 else
                 {
                     var warned = Context.Guild.GetUser(warning.WarnedUserID);
+                    var warnedSafe = Extensions.FormatMentionDetailed(warned);
+                    var warnedBySafe = Extensions.FormatMentionDetailed(warnedBy);
                     embed.AddField(new EmbedFieldBuilder()
                         .WithName($"Warning #{counter} - {warning.Date.ToString("dd/M/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}")
-                        .WithValue($"**Warned user**: {warned?.Mention ?? warning.WarnedUser}\n" +
+                        .WithValue($"**Warned user**: {warnedSafe}\n" +
                                    $"**Reason**: {warning.Reason}\n" +
-                                   $"**Warned by**: {warnedBy?.Mention ?? warning.WarnedBy}"))
+                                   $"**Warned by**: {warnedBySafe}"))
                         .WithFooter("*For more detailed info, consult the individual lists.*");
                 }
             }

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -41,7 +41,7 @@ namespace OnePlusBot.Modules
             embed.AddField(x =>
             {
                 x.Name = "Username";
-                x.Value = user.Mention;
+                x.Value = Extensions.FormatMentionDetailed(user);
                 x.IsInline = true;
             });
             embed.AddField(x =>
@@ -201,10 +201,12 @@ namespace OnePlusBot.Modules
                     .WithName("Woah...")
                     .WithIconUrl("https://a.kyot.me/cno0.png");
             });
+            var reportedUserSafe = Extensions.FormatMentionDetailed(user);
+            var reporterUserSafe = Extensions.FormatMentionDetailed(reporter);
 
             const string discordUrl = "https://discordapp.com/channels/{0}/{1}/{2}";
-            builder.AddField("Reported User", user?.Mention ?? entry.ReportedUser + "(" + entry.ReportedUserId + ")")
-                .AddField("Reported by", reporter?.Mention ?? entry.ReportedBy + "(" + entry.ReportedById + ")")
+            builder.AddField("Reported User", reportedUserSafe)
+                .AddField("Reported by", reporterUserSafe)
                 .AddField(
                     "Location of the incident",
                     $"[#{Context.Message.Channel.Name}]({string.Format(discordUrl, Context.Guild.Id, Context.Channel.Id, Context.Message.Id)})")


### PR DESCRIPTION
This PR changes the places at which users are mentioned to instead post the mention, the username + discriminator and the user id instead.

This is helpful for mobile clients, as people are only shown as 'invalid-user' in case they left the server. On desktop only the ID is shown, but this helps for easier identification too.