### PR TITLE
Added update mechanic to news post

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -126,6 +126,21 @@ namespace OnePlusBot.Base
 
             if(before.Author.IsBot)
                 return;
+            
+            if(Global.NewsPosts.ContainsKey(message.Id))
+            {
+                var split = message.Content.Split(";news");
+                if(split.Length > 0)
+                {
+                    var guild = Global.Bot.GetGuild(Global.ServerID);
+                    var newsChannel = guild.GetTextChannel(Global.Channels["news"]);
+                    var newsRole = guild.GetRole(Global.Roles["news"]);
+                    var existingMessage = await newsChannel.GetMessageAsync(Global.NewsPosts[message.Id]) as SocketUserMessage;
+                    await newsRole.ModifyAsync(x => x.Mentionable = true);
+                    await existingMessage.ModifyAsync(x => x.Content = split[1] + Environment.NewLine + Environment.NewLine + newsRole.Mention + Environment.NewLine + "- " + author);
+                    await newsRole.ModifyAsync(x => x.Mentionable = false);
+                }
+            }
 
             var fullChannel = Extensions.GetChannelById(message.Channel.Id);
             if(fullChannel != null){
@@ -305,6 +320,17 @@ namespace OnePlusBot.Base
         {
             switch(result)
             {
+                case PreconditionResult conditionResult:
+                    if (conditionResult.IsSuccess)
+                    {
+                        await context.Message.AddReactionAsync(Global.OnePlusEmote.SUCCESS);
+                    }
+                    else
+                    {
+                        await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);
+                        await context.Channel.SendMessageAsync(conditionResult.ErrorReason);
+                    }
+                    break;
                 case CustomResult customResult:
                     if (customResult.IsSuccess)
                     {

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -18,6 +18,8 @@ namespace OnePlusBot.Base
         public static ulong ServerID { get; }
         public static Dictionary<string, ulong> Roles { get; }
         public static Dictionary<string, ulong> Channels { get; }
+
+        public static Dictionary<ulong, ulong> NewsPosts { get; }
         public static List<Channel> FullChannels {get;}
 
         public static ulong CommandExecutorId { get; set; }
@@ -79,7 +81,7 @@ namespace OnePlusBot.Base
                         FullChannels.Add(channel);
                     }
                        
-                        
+                NewsPosts = new Dictionary<ulong, ulong>();
                 
                 Roles = new Dictionary<string, ulong>();
                 if (db.Roles.Any())

--- a/src/OnePlusBot/Base/RequireRole.cs
+++ b/src/OnePlusBot/Base/RequireRole.cs
@@ -1,0 +1,31 @@
+using System.Runtime.CompilerServices;
+using System.Linq;
+using System.Net;
+using System;
+using System.Threading.Tasks;
+using Discord.Commands;
+using Discord.WebSocket;
+using OnePlusBot.Base;
+using Discord;
+
+
+public class RequireRole : PreconditionAttribute
+{
+    private readonly string AllowedRole;
+
+    // this is executed very early in the lifecycle, we dont have a server object or bot object yet
+    public RequireRole(string name) => this.AllowedRole = name;
+
+    public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+    {
+        var bot = Global.Bot;
+        var guild = bot.GetGuild(Global.ServerID);
+        var iGuildObj = (IGuild) guild;
+        var allowedroleObj =  iGuildObj.GetRole(Global.Roles[this.AllowedRole]);
+        var user = (SocketGuildUser) context.User;
+        if(user.Roles.Any(role => role.Id == allowedroleObj.Id)){
+            return Task.FromResult(PreconditionResult.FromSuccess());
+        } 
+        return Task.FromResult(PreconditionResult.FromError($"You need the role {this.AllowedRole} to perform this command."));
+    }
+}

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -220,7 +220,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("news"),
-            Summary("Posts a News article to the server.")
+            Summary("Posts a News article to the server."),
+            RequireRole("journalist")
         ]
         public async Task<RuntimeResult> NewsAsync([Remainder] string news)
         {
@@ -229,18 +230,15 @@ namespace OnePlusBot.Modules
             var user = (SocketGuildUser)Context.Message.Author;
             var newsChannel = guild.GetTextChannel(Global.Channels["news"]);
             var newsRole = guild.GetRole(Global.Roles["news"]);
-            var journalistRole = guild.GetRole(Global.Roles["journalist"]);
 
             if (news.Contains("@everyone") || news.Contains("@here") || news.Contains("@news")) 
                 return CustomResult.FromError("Your news article contained one or more illegal pings!");
 
-
-            if (!user.Roles.Contains(journalistRole))
-                return CustomResult.FromError("Only Journalists can post news.");
-
             await newsRole.ModifyAsync(x => x.Mentionable = true);
-            await newsChannel.SendMessageAsync(news + Environment.NewLine + Environment.NewLine + newsRole.Mention + Environment.NewLine + "- " + Context.Message.Author);
+            var posted = await newsChannel.SendMessageAsync(news + Environment.NewLine + Environment.NewLine + newsRole.Mention + Environment.NewLine + "- " + Context.Message.Author);
             await newsRole.ModifyAsync(x => x.Mentionable = false);
+
+            Global.NewsPosts[Context.Message.Id] = posted.Id;
 
             return CustomResult.FromSuccess();
         }


### PR DESCRIPTION
With this PR, every time the source message of a news post is updated, the resulting news post will get updated. This is only possible, during the active session of the Bot.

It also includes a minor refactor of the way the journalist role is checked, by adding a condition enabling role checks by name.