### PR TITLE
Update Support.cs - add one more way to get in EDL mode and information about readback mode of MSM tool

### DIFF
--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -357,7 +357,7 @@ namespace OnePlusBot.Modules
                     case "9008mode":
                         if (Context.Channel.Name == "oneplus7-series" || Context.Channel.Name == "oneplus6-6t")
                         {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("To enter in Qualcomm EDL mode, you can use `adb reboot edl` or use any version of blu_spark TWRP based on TWRP 3.3.0 or later by clicking on `Reboot to EDL`. You can also power off your device, wait 10 seconds and maintain volume up and down keys." + Environment.NewLine +
+                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("To enter in Qualcomm EDL mode, you can use `adb reboot edl` or use any version of blu_spark TWRP based on TWRP 3.3.0 or later by clicking on `Reboot to EDL`. An alternative way is using `reboot edl` command in a rooted terminal emulator on your device. You can also power off your device, wait 10 seconds and maintain volume up and down keys." + Environment.NewLine +
                                              "If you want to exit EDL mode, maintain power button during at least 10 seconds " + Environment.NewLine +
                                              "You can use a generic USB-C cable however, OnePlus official cable are preferable"));
                         }

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -459,6 +459,12 @@ namespace OnePlusBot.Modules
                                              "If you want to avoid data of a specific application to be restored, you can get in `MobileBackup --> App` in `opbackup` folder to delete the .tar file associated to the app (eg: `com.whatsapp.tar` for data of WhatsApp)"));
                         }
                         break;
+                    case "readback":
+                        {
+                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("You can use readback function of MSM tool to dump your device partitions. They will be stored at the root of your system drive and have .img as file extension. For that, get in EDL mode, open MSM tool, press F8, tick partitions you want to dump, input `oneplus` as password, press `ok` and click on Reaback button" + Environment.NewLine +
+                                             "Dumped partitions are flashable by fastboot."));
+                        }
+                        break;
                     //placeholder for any new FAQ entry that might be added in the future
                     default:
                         await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Supported FAQ commands are: repairprices, bluspark, googlecamera, oxygenos, unbrick, edl, magisk, root, qualcommdiagnostics, smt, qpreview, updateschedule, adbfastbootpath, saharacommunicationfailed, oneplusswitch" + Environment.NewLine + 

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -461,13 +461,13 @@ namespace OnePlusBot.Modules
                         break;
                     case "readback":
                         {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("You can use readback function of MSM tool to dump your device partitions. They will be stored at the root of your system drive and have .img as file extension. For that, get in EDL mode, open MSM tool, press F8, tick partitions you want to dump, input `oneplus` as password, press `ok` and click on Reaback button" + Environment.NewLine +
+                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("You can use readback function of MSM tool to dump your device partitions. They will be stored at the root of your system drive and have .img as file extension. For that, get in EDL mode, open MSM tool, press F8, tick partitions you want to dump, input `oneplus` as password, press `ok` and click on Readback button" + Environment.NewLine +
                                              "Dumped partitions are flashable by fastboot."));
                         }
                         break;
                     //placeholder for any new FAQ entry that might be added in the future
                     default:
-                        await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Supported FAQ commands are: repairprices, bluspark, googlecamera, oxygenos, unbrick, edl, magisk, root, qualcommdiagnostics, smt, qpreview, updateschedule, adbfastbootpath, saharacommunicationfailed, oneplusswitch" + Environment.NewLine + 
+                        await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Supported FAQ commands are: repairprices, bluspark, googlecamera, oxygenos, unbrick, edl, magisk, root, qualcommdiagnostics, smt, qpreview, updateschedule, adbfastbootpath, saharacommunicationfailed, oneplusswitch, readback" + Environment.NewLine + 
                                          "Mind that some commands can only be used in specific (device)channels"));
                         break;
                 }


### PR DESCRIPTION
First commit add information about readback mode of MSM tool. Tested on my device with system partition.

![image](https://user-images.githubusercontent.com/42769194/62884982-0f0f7400-bd38-11e9-9542-0110faaa33bf.png)
![image](https://user-images.githubusercontent.com/42769194/62884999-19ca0900-bd38-11e9-9cd7-f5ffa1d68205.png)
![image](https://user-images.githubusercontent.com/42769194/62885079-3fefa900-bd38-11e9-92cd-22439496ad53.png)
![image](https://user-images.githubusercontent.com/42769194/62885156-66addf80-bd38-11e9-859d-6ce9012cb047.png)

Second commit add one more way of getting into EDL mode