### PR TITLE
added message content to profanity message, fixes #91

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -495,7 +495,8 @@ namespace OnePlusBot.Base
             builder.AddField("User in question ", Extensions.FormatMentionDetailed(message.Author))
                 .AddField(
                     "Location of the profane message",
-                    $"[#{message.Channel.Name}]({string.Format(discordUrl, guild.Id, message.Channel.Id, message.Id)})");
+                    $"[#{message.Channel.Name}]({string.Format(discordUrl, guild.Id, message.Channel.Id, message.Id)})")
+                .AddField("Message content", message.Content);
 
 
             var embed = builder.Build();


### PR DESCRIPTION
To see faster (and easier on mobile) we should also actually post the message to modlog, so the decision can be made easier in case of false positives.