### PR TITLE
fixed null handling for user unmute

### DIFF
--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -109,7 +109,8 @@ namespace OnePlusBot.Base
       return result;
     }
 
-    public static void UnMuteUserCompletely(ulong userId, Database db){
+    public static void UnMuteUserCompletely(ulong userId, Database db)
+    {
       var mutedObjs = db.Mutes.Where(x => x.MutedUserID == userId).ToList();
       foreach(var mutedEl in mutedObjs)
       {
@@ -117,7 +118,8 @@ namespace OnePlusBot.Base
       }
     }
 
-    public static void UnMuteUserCompletely(ulong userId){
+    public static void UnMuteUserCompletely(ulong userId)
+    {
       using (var db = new Database())
       {
         UnMuteUserCompletely(userId, db);

--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -1,5 +1,3 @@
-using System.Data.Common;
-using System.Xml.Linq;
 using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
@@ -12,96 +10,119 @@ using Discord.WebSocket;
 
 namespace OnePlusBot.Base
 {
-    public class MuteTimerManager 
+  public class MuteTimerManager 
+  {
+    public static async Task<RuntimeResult> SetupTimers(Boolean startup)
     {
-        public static async Task<RuntimeResult> SetupTimers(Boolean startup)
+      var bot = Global.Bot;
+      var guild = bot.GetGuild(Global.ServerID);
+      var iGuildObj = (IGuild) guild;
+      using (var db = new Database())
+      {
+        var maxDate = DateTime.Now.AddHours(1);
+        var allusers = await iGuildObj.GetUsersAsync();
+        var mutesInFuture = db.Mutes.Where(x => x.UnmuteDate < maxDate && !x.MuteEnded).ToList();
+        if(mutesInFuture.Any())
         {
-          var bot = Global.Bot;
-          var guild = bot.GetGuild(Global.ServerID);
-          var iGuildObj = (IGuild) guild;
-          using (var db = new Database())
+          foreach (var futureUnmute in mutesInFuture)
           {
-            var maxDate = DateTime.Now.AddHours(1);
-            var allusers = await iGuildObj.GetUsersAsync();
-            var mutesInFuture = db.Mutes.Where(x => x.UnmuteDate < maxDate && !x.MuteEnded).ToList();
-            if(mutesInFuture.Any())
+            var userObj = allusers.FirstOrDefault(x => x.Id == futureUnmute.MutedUserID);
+            if(userObj == null)
             {
-              foreach (var futureUnmute in mutesInFuture)
-              {
-                var userObj = allusers.FirstOrDefault(x => x.Id == futureUnmute.MutedUserID);
-                await Task.Delay(1 * 1000);
-                var timeToUnmute = futureUnmute.UnmuteDate - DateTime.Now;
-                if(timeToUnmute.TotalMilliseconds < 0)
-                {
-                  timeToUnmute = TimeSpan.FromSeconds(1);
-                }
-                // the reason why I am dragging the IDs into the function call is to be sure, that the objects are still valid when the unmute function is executed
-                UnmuteUserIn(userObj.Id, timeToUnmute, futureUnmute.ID);
-              }
-            }    
-          }
-          if(startup)
-          {
-            System.Timers.Timer timer1 = new System.Timers.Timer(1000 * 60 * 60);
-            timer1.Elapsed += new System.Timers.ElapsedEventHandler(TriggerTimer);
-            timer1.Enabled = true;
-          }
-          return CustomResult.FromSuccess();
-        }
-
-        public static async void TriggerTimer(object sender, System.Timers.ElapsedEventArgs e)
-        {
-          System.Timers.Timer timer = (System.Timers.Timer)sender;
-          await SetupTimers(false);
-        }        
-
-        public static async void UnmuteUserIn(ulong userId, TimeSpan time, ulong muteId)
-        {
-          await Task.Delay((int)time.TotalMilliseconds);
-          await UnMuteUser(userId, muteId);
-        }
-
-        public static async Task<CustomResult> UnMuteUser(ulong userId, ulong muteId)
-        {
-          var bot = Global.Bot;
-          var guild = bot.GetGuild(Global.ServerID);
-          var user = guild.GetUser(userId);
-          var result = await OnePlusBot.Helpers.Extensions.UnMuteUser(user);
-          if(!result.IsSuccess)
-          {
-            return result;
-          }
-          using (var db = new Database())
-          {
-            if(muteId == UInt64.MaxValue)
-            {
-              // this is in case we directly unmute a person via a command, just set all of the mutes to ended, in case there are more than one
-              var mutedObjs = db.Mutes.Where(x => x.MutedUserID == userId).ToList();
-              foreach(var mutedEl in mutedObjs)
-              {
-                mutedEl.MuteEnded = true;
-              }
+              UnMuteUserCompletely(futureUnmute.MutedUserID, db);
+              continue;
             }
-            else 
+            await Task.Delay(1 * 1000);
+            var timeToUnmute = futureUnmute.UnmuteDate - DateTime.Now;
+            if(timeToUnmute.TotalMilliseconds < 0)
             {
-              var muteObj = db.Mutes.Where(x => x.ID == muteId).ToList().First();
-              if(!muteObj.MuteEnded)
-              {
-                muteObj.MuteEnded = true;
-                var noticeEmbed = new EmbedBuilder();
-                noticeEmbed.Color = Color.LightOrange;
-                noticeEmbed.Title = "User has been unmuted!";
-                noticeEmbed.ThumbnailUrl = user.GetAvatarUrl();
-
-                noticeEmbed.AddField("Unmuted User", OnePlusBot.Helpers.Extensions.FormatUserName(user))
-                           .AddField("Mute Id", muteId)
-                           .AddField("Muted since", $"{ muteObj.MuteDate:dd.MM.yyyy HH:mm}");
-                await guild.GetTextChannel(Global.Channels["modlog"]).SendMessageAsync(embed: noticeEmbed.Build());
-              }
+              timeToUnmute = TimeSpan.FromSeconds(1);
             }
-            db.SaveChanges();
+            // the reason why I am dragging the IDs into the function call is to be sure, that the objects are still valid when the unmute function is executed
+            UnmuteUserIn(userObj.Id, timeToUnmute, futureUnmute.ID);
           }
-          return result;
-        }
+        }    
+        db.SaveChanges();
       }
+      if(startup)
+      {
+        System.Timers.Timer timer1 = new System.Timers.Timer(1000 * 60 * 60);
+        timer1.Elapsed += new System.Timers.ElapsedEventHandler(TriggerTimer);
+        timer1.Enabled = true;
+      }
+      return CustomResult.FromSuccess();
+    }
+
+    public static async void TriggerTimer(object sender, System.Timers.ElapsedEventArgs e)
+    {
+      System.Timers.Timer timer = (System.Timers.Timer)sender;
+      await SetupTimers(false);
+    }        
+
+    public static async void UnmuteUserIn(ulong userId, TimeSpan time, ulong muteId)
+    {
+      await Task.Delay((int)time.TotalMilliseconds);
+      await UnMuteUser(userId, muteId);
+    }
+
+    public static async Task<CustomResult> UnMuteUser(ulong userId, ulong muteId)
+    {
+      var bot = Global.Bot;
+      var guild = bot.GetGuild(Global.ServerID);
+      var user = guild.GetUser(userId);
+      if(user == null)
+      {
+        UnMuteUserCompletely(userId);
+        return CustomResult.FromError("User is not in the server anymore");
+      }
+      var result = await OnePlusBot.Helpers.Extensions.UnMuteUser(user);
+      if(!result.IsSuccess)
+      {
+        return result;
+      }
+      using (var db = new Database())
+      {
+        if(muteId == UInt64.MaxValue)
+        {
+          // this is in case we directly unmute a person via a command, just set all of the mutes to ended, in case there are more than one
+          UnMuteUserCompletely(userId, db);
+        }
+        else 
+        {
+          var muteObj = db.Mutes.Where(x => x.ID == muteId).ToList().First();
+          if(!muteObj.MuteEnded)
+          {
+            muteObj.MuteEnded = true;
+            var noticeEmbed = new EmbedBuilder();
+            noticeEmbed.Color = Color.LightOrange;
+            noticeEmbed.Title = "User has been unmuted!";
+            noticeEmbed.ThumbnailUrl = user.GetAvatarUrl();
+
+            noticeEmbed.AddField("Unmuted User", OnePlusBot.Helpers.Extensions.FormatUserName(user))
+                        .AddField("Mute Id", muteId)
+                        .AddField("Muted since", $"{ muteObj.MuteDate:dd.MM.yyyy HH:mm}");
+            await guild.GetTextChannel(Global.Channels["modlog"]).SendMessageAsync(embed: noticeEmbed.Build());
+          }
+        }
+        db.SaveChanges();
+      }
+      return result;
+    }
+
+    public static void UnMuteUserCompletely(ulong userId, Database db){
+      var mutedObjs = db.Mutes.Where(x => x.MutedUserID == userId).ToList();
+      foreach(var mutedEl in mutedObjs)
+      {
+        mutedEl.MuteEnded = true;
+      }
+    }
+
+    public static void UnMuteUserCompletely(ulong userId){
+      using (var db = new Database())
+      {
+        UnMuteUserCompletely(userId, db);
+        db.SaveChanges();
+      }
+    }
+  }
 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -29,6 +29,8 @@ namespace OnePlusBot.Modules
             var modlog = Context.Guild.GetTextChannel(Global.Channels["modlog"]);
             await Context.Guild.AddBanAsync(name, 0, reason);
 
+            MuteTimerManager.UnMuteUserCompletely(name);
+
             return CustomResult.FromSuccess();
         }
     
@@ -53,6 +55,9 @@ namespace OnePlusBot.Modules
                                           "If you believe this to be a mistake, please send an appeal e-mail with all the details to oneplus.appeals@pm.me";
                 await user.SendMessageAsync(string.Format(banMessage, reason));
                 await Context.Guild.AddBanAsync(user, 0, reason);
+
+                MuteTimerManager.UnMuteUserCompletely(user.Id);
+
                 return CustomResult.FromSuccess();
 
             }
@@ -81,6 +86,7 @@ namespace OnePlusBot.Modules
                 return CustomResult.FromError("You can't kick staff.");
 
             await user.KickAsync(reason);
+            MuteTimerManager.UnMuteUserCompletely(user.Id);
             return CustomResult.FromSuccess();
         }
 


### PR DESCRIPTION
The user gets removed from the mutes table in case he got kicked/banned.
Added null checks at all the places a user can be unmuted from. (also updating the values in the database accordingly)