### PR TITLE
FAQ Rework

### DIFF
--- a/src/OnePlusBot/Base/ConfigurationStep.cs
+++ b/src/OnePlusBot/Base/ConfigurationStep.cs
@@ -1,0 +1,169 @@
+using System.Text;
+using System.Collections.ObjectModel;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using Discord.Addons.Interactive;
+
+namespace OnePlusBot.Base {
+    public class ConfigurationStep : IReactionCallback 
+    {
+
+        public enum StepType { Text, Reaction};
+
+        public object Result;
+        public SocketCommandContext Context { get; }
+        public InteractiveService Interactive { get; private set; }
+        public IUserMessage Message { get; private set; }
+
+        public Collection<IMessage> PostedMessages = new Collection<IMessage>();
+        public TimeSpan? Timeout => TimeSpan.FromMinutes(3);
+
+        public ICriterion<SocketReaction> Criterion => _criterion;
+
+        private readonly ICriterion<SocketReaction> _criterion;
+
+        public RunMode RunMode => RunMode.Sync;
+        private StepType type;
+
+        private ConfigurationStep parent;
+        public Collection<string> additionalPosts = new Collection<string>();
+
+        public Func<String, bool> TextCallback { get; set; }
+
+        public Func<ConfigurationStep, bool> beforeTextPosted { get; set; }
+
+        public ConfigurationStep(string description, InteractiveService interactive, SocketCommandContext context, StepType type, ConfigurationStep parent)
+        {
+            this.Interactive = interactive;
+            this.description = description;
+            Context = context;
+            _criterion =  new ReactionSameUserCriterion();
+            this.type = type;
+            this.parent = parent;
+        }
+        private string description { get; set; }
+
+        public Collection<ReactionAction> Actions = new Collection<ReactionAction>();
+
+        public async Task SetupMessage()
+        {
+            PostedMessages = new Collection<IMessage>();
+            Interactive.ClearReactionCallbacks();
+            if(this.beforeTextPosted != null)
+            {
+                this.beforeTextPosted(this);
+            }
+            if(additionalPosts.Count > 0)
+            {
+                var additionalPostsString = new StringBuilder();
+                foreach(var text in additionalPosts)
+                {
+                    additionalPostsString.Append(text + Environment.NewLine);
+                }
+                var value = additionalPostsString.ToString();
+                if(value != string.Empty)
+                {
+                    var message = await Context.Channel.SendMessageAsync(value);
+                    PostedMessages.Add(message);
+                }
+            }
+           
+            this.Message = await Context.Channel.SendMessageAsync(description);
+            PostedMessages.Add(this.Message);
+            if(type == StepType.Reaction)
+            {
+                var emotes = new Collection<IEmote>();
+                foreach(var action in Actions)
+                {
+                    emotes.Add(action.Emote);
+                }
+                await Message.AddReactionsAsync(emotes.ToArray());
+                Interactive.AddReactionCallback(this.Message, this);
+            }
+            else 
+            {
+                var response = await Interactive.NextMessageAsync(Context, true, true, TimeSpan.FromMinutes(2));
+                Result = response.Content;
+                await response.DeleteAsync();
+                reactBasedOnResult();
+            }
+
+            if (Timeout.HasValue && Timeout.Value != null)
+            {
+                _ = Task.Delay(Timeout.Value).ContinueWith(async _ =>
+                {
+                    if(Message != null)
+                    {
+                        Interactive.RemoveReactionCallback(Message);
+                    }
+                    
+                    foreach(var message in PostedMessages)
+                    {
+                        await message.DeleteAsync();
+                    }  
+                    
+                });
+            }
+            
+            
+        }
+
+        private async Task reactBasedOnResult()
+        {
+            foreach(var message in PostedMessages)
+            {
+                await Context.Channel.DeleteMessageAsync(message);
+            }
+            PostedMessages.Clear();
+            if(Result != null){
+                if(Result is ConfigurationStep)
+                {
+                    var casted = Result as ConfigurationStep;
+                    await casted.SetupMessage();
+                }
+                else if(Result is string)
+                {
+                    this.TextCallback(Result as string);
+                    await this.parent.SetupMessage();
+                }
+            }
+           
+        }
+
+        public async Task<bool> HandleCallbackAsync(SocketReaction reaction)
+        {
+            var emote = reaction.Emote;
+            foreach(var action in Actions)
+            {
+                if(action.Emote.Equals(emote))
+                {
+                    action.Action(this);
+                }
+            }
+            await Task.Delay(500);
+
+            reactBasedOnResult();
+            
+            return true;
+        }
+        
+    }
+
+    public class ReactionAction 
+    {
+        public IEmote Emote { get; set; }
+        public Func<ConfigurationStep,bool> Action { get; set; }
+
+        public ReactionAction(IEmote emote) 
+        {
+            this.Emote = emote;
+        }
+
+    }
+
+    
+}

--- a/src/OnePlusBot/Base/RequireRole.cs
+++ b/src/OnePlusBot/Base/RequireRole.cs
@@ -9,23 +9,27 @@ using OnePlusBot.Base;
 using Discord;
 
 
-public class RequireRole : PreconditionAttribute
+namespace OnePlusBot.Base
 {
-    private readonly string AllowedRole;
 
-    // this is executed very early in the lifecycle, we dont have a server object or bot object yet
-    public RequireRole(string name) => this.AllowedRole = name;
-
-    public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+    public class RequireRole : PreconditionAttribute
     {
-        var bot = Global.Bot;
-        var guild = bot.GetGuild(Global.ServerID);
-        var iGuildObj = (IGuild) guild;
-        var allowedroleObj =  iGuildObj.GetRole(Global.Roles[this.AllowedRole]);
-        var user = (SocketGuildUser) context.User;
-        if(user.Roles.Any(role => role.Id == allowedroleObj.Id)){
-            return Task.FromResult(PreconditionResult.FromSuccess());
-        } 
-        return Task.FromResult(PreconditionResult.FromError($"You need the role {this.AllowedRole} to perform this command."));
+        private readonly string AllowedRole;
+
+        // this is executed very early in the lifecycle, we dont have a server object or bot object yet
+        public RequireRole(string name) => this.AllowedRole = name;
+
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+        {
+            var bot = Global.Bot;
+            var guild = bot.GetGuild(Global.ServerID);
+            var iGuildObj = (IGuild) guild;
+            var allowedroleObj =  iGuildObj.GetRole(Global.Roles[this.AllowedRole]);
+            var user = (SocketGuildUser) context.User;
+            if(user.Roles.Any(role => role.Id == allowedroleObj.Id)){
+                return Task.FromResult(PreconditionResult.FromSuccess());
+            } 
+            return Task.FromResult(PreconditionResult.FromError($"You need the role {this.AllowedRole} to perform this command."));
+        }
     }
 }

--- a/src/OnePlusBot/Base/SameUserCriterion.cs
+++ b/src/OnePlusBot/Base/SameUserCriterion.cs
@@ -1,0 +1,15 @@
+using System.Threading.Tasks;
+using Discord.Commands;
+using Discord.WebSocket;
+using Discord.Addons.Interactive;
+   
+namespace OnePlusBot.Base
+{
+    internal class ReactionSameUserCriterion : ICriterion<SocketReaction>
+    {
+        public Task<bool> JudgeAsync(SocketCommandContext sourceContext, SocketReaction parameter)
+        {
+            return Task.FromResult(parameter.UserId == sourceContext.User.Id);
+        }
+    }
+}

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -2,6 +2,9 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using MySql.Data.MySqlClient;
 using OnePlusBot.Data.Models;
+using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Console;
 
 namespace OnePlusBot.Data
 {
@@ -15,9 +18,18 @@ namespace OnePlusBot.Data
         public DbSet<ProfanityCheck> ProfanityChecks { get; set; }
         public DbSet<ReportEntry> Reports { get; set; }
         public DbSet<ReferralCode> ReferralCodes { get; set; }
+
+        public DbSet<FAQCommand> FAQCommands { get; set;}
+        public DbSet<FAQCommandChannel> FAQCommandChannels { get; set;}
+
+        public DbSet<FAQCommandChannelEntry> FAQCommandChannelEntries { get; set; }
         public DbSet<WarnEntry> Warnings { get; set; }
 
         public DbSet<Mute> Mutes {get; set; }
+
+        // TODO needs to be replaced with proper dependency injection
+        public static readonly LoggerFactory LoggerFactory
+        = new LoggerFactory(new[] {new ConsoleLoggerProvider((_, __) => true, true)});
 
         protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
         {
@@ -37,7 +49,10 @@ namespace OnePlusBot.Data
                 Password = pwd
             };
             
+
             optionsBuilder.UseMySql(connStr.ToString());
+            optionsBuilder.UseLoggerFactory(LoggerFactory);
+            optionsBuilder.EnableDetailedErrors();
         }
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using Discord;
+using System.Collections.Generic;
 
 namespace OnePlusBot.Data.Models
 {
@@ -25,5 +26,8 @@ namespace OnePlusBot.Data.Models
 
         [Column("profanity_check_exempt")]
         public bool ProfanityCheckExempt{ get; set;}
+
+        public virtual ICollection<FAQCommandChannel> CommandChannels { get; set; }
+
     }
 }

--- a/src/OnePlusBot/Data/Models/FAQCommand.cs
+++ b/src/OnePlusBot/Data/Models/FAQCommand.cs
@@ -1,0 +1,35 @@
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using OnePlusBot.Helpers;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("FaqCommand")]
+    public class FAQCommand : IPaginatable
+    {
+        [Key]
+        [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public uint ID { get; set; }
+        
+        [Column("name")]
+        public string Name { get; set; }
+
+        // comma separated, there is no need for an extra table for just this
+        [Column("aliases")]
+        public string Aliases{ get; set;}
+
+        public string[] IndividualAliases() {
+            var stringToSplit = Aliases ?? string.Empty;
+            return stringToSplit.Split(',') ;
+        }
+        
+        public virtual ICollection<FAQCommandChannel> CommandChannels { get; set; }
+
+        public string display(){
+            return $"command: {Name}";
+        }
+    }
+}

--- a/src/OnePlusBot/Data/Models/FAQCommandChannel.cs
+++ b/src/OnePlusBot/Data/Models/FAQCommandChannel.cs
@@ -1,0 +1,37 @@
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using OnePlusBot.Helpers;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("FaqCommandChannel")]
+    public class FAQCommandChannel : IPaginatable
+    {
+
+        [Key]
+        [Column("command_channel_id")]
+        public uint CommandChannelId { get; set; }
+
+        [Column("command_id")]
+        public uint FAQCommandId { get; set; }
+
+        [Column("channel_id")]
+        public uint ChannelId { get; set; }
+
+
+        [ForeignKey("ChannelId")]
+        public virtual Channel Channel { get; set; }
+
+
+        [ForeignKey("FAQCommandId")]
+        public virtual FAQCommand Command { get; set; }
+    
+        public virtual ICollection<FAQCommandChannelEntry> CommandChannelEntries { get; set; }
+
+        public string display(){
+            return $"ID: {CommandChannelId}: command: {Command.Name} in {Channel.Name}";
+        }
+    }
+}

--- a/src/OnePlusBot/Data/Models/FaqCommandChannelEntry.cs
+++ b/src/OnePlusBot/Data/Models/FaqCommandChannelEntry.cs
@@ -1,0 +1,61 @@
+
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("FAQCommandChannelEntry")]
+    public class FAQCommandChannelEntry
+    {
+       
+
+        [Key]
+        [Column("entry_id", Order=0)]
+        public uint EntryId { get; set; }
+        
+        [Column("text")]
+        public string Text { get; set; }
+
+        [Column("is_embed")]
+        public bool IsEmbed { get; set; }
+
+        [Column("image_url")]
+        public string ImageURL { get; set; }
+
+        [Column("hex_color")]
+        public uint HexColor { get; set; }
+
+        [Column("position")]
+        public uint Position { get; set; }
+
+        [Column("command_channel_id")]
+        public uint CommandChannelId { get; set; }
+
+        [Column("author")]
+        public string Author { get; set; }
+
+        [Column("author_avatar_url")]
+        public string AuthorAvatarUrl { get; set; }
+
+
+        [ForeignKey("CommandChannelId")]
+        public virtual FAQCommandChannel FAQCommandChannel { get; set; }
+
+    
+        // TODO should not be necessary, there is entity state detach, did not work for me
+        public FAQCommandChannelEntry clone(){
+            var clone = new FAQCommandChannelEntry();
+            clone.Author = Author;
+            clone.AuthorAvatarUrl = AuthorAvatarUrl;
+            clone.Position = Position;
+            clone.HexColor = HexColor;
+            clone.ImageURL = ImageURL;
+            clone.IsEmbed = IsEmbed;
+            clone.Text = Text;
+            return clone;
+        }
+
+
+    }
+}

--- a/src/OnePlusBot/Data/Models/FaqCommandChannelEntryBuilder.cs
+++ b/src/OnePlusBot/Data/Models/FaqCommandChannelEntryBuilder.cs
@@ -1,0 +1,46 @@
+namespace OnePlusBot.Data.Models
+{
+    public class FaqCommandChannelEntryBuilder {
+        FAQCommandChannelEntry entry = new FAQCommandChannelEntry();
+
+        public FaqCommandChannelEntryBuilder withText(string value){
+            entry.Text = value;
+            return this;
+        }
+
+        public FaqCommandChannelEntryBuilder withImageUrl(string value){
+            entry.ImageURL = value;
+            return this;
+        }
+
+        public FaqCommandChannelEntryBuilder withAuthor(string value){
+            entry.Author = value;
+            return this;
+        }
+
+        public FaqCommandChannelEntryBuilder withHexColor(uint value){
+            entry.HexColor = value;
+            return this;
+        }
+
+        public FaqCommandChannelEntryBuilder withAuthorAvatarUrl(string value){
+            entry.AuthorAvatarUrl = value;
+            return this;
+        }
+
+        public FaqCommandChannelEntryBuilder withIsEmbed(bool value){
+            entry.IsEmbed = value;
+            return this;
+        }
+
+        public FaqCommandChannelEntryBuilder defaultValues(){
+            this.withAuthor("r/Oneplus");
+            this.withAuthorAvatarUrl("https://cdn.discordapp.com/avatars/426015562595041280/cab7dde68e8da9bcfd61842bd98e950b.png");
+            return this;
+        }
+
+        public FAQCommandChannelEntry Build(){
+            return entry;
+        }
+    }
+}

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -74,5 +74,17 @@ namespace OnePlusBot.Helpers
         public static Channel GetChannelById(ulong channelId){
             return Global.FullChannels.Where(chan => chan.ChannelID == channelId).DefaultIfEmpty(null).First();
         }
+
+        public static EmbedBuilder FaqCommandEntryToBuilder(FAQCommandChannelEntry entry) {
+            var faqEmbedEntry = new EmbedBuilder();
+            faqEmbedEntry.WithColor(new Color(entry.HexColor));
+            faqEmbedEntry.WithDescription(entry.Text);
+            if(entry.ImageURL != null){
+                faqEmbedEntry.WithImageUrl(entry.ImageURL);
+            }
+            faqEmbedEntry.WithAuthor(entry.Author, entry.AuthorAvatarUrl);
+
+            return faqEmbedEntry;
+        }
     }
 }

--- a/src/OnePlusBot/Helpers/Paginatable.cs
+++ b/src/OnePlusBot/Helpers/Paginatable.cs
@@ -1,0 +1,8 @@
+
+namespace OnePlusBot.Helpers
+{
+    public interface IPaginatable
+    {
+        string display();
+    } 
+}

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -487,5 +487,17 @@ namespace OnePlusBot.Modules
                 });
             }
         }
+
+        [
+            Command("reloaddb"),
+            Summary("Reloades the cached info from db"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> ReloadDB()
+        {
+            await Task.Delay(500);
+            Global.LoadGlobal();
+            return CustomResult.FromSuccess();
+        }
     }
 }

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -1,0 +1,513 @@
+using System;
+using Discord.Commands;
+using Discord;
+using System.Linq;
+using System.Threading.Tasks;
+using OnePlusBot.Helpers;
+using Discord.Addons.Interactive;
+using OnePlusBot.Base;
+using OnePlusBot.Data;
+using OnePlusBot.Data.Models;
+using System.Text.RegularExpressions;
+using System.Collections.Generic;    
+
+
+namespace OnePlusBot.Modules
+{
+    public class FAQConfiguration : InteractiveBase<SocketCommandContext>
+    {
+
+        [
+            Command("configureFAQ", RunMode = RunMode.Async),
+            Summary("Configures the faq command entries."),
+            RequireRole("staff")
+        ]
+        public async Task ConfigureFAQ()
+        {
+            var guild = Global.Bot.GetGuild(Global.ServerID);
+            var configurationStep = new ConfigurationStep("What do you want to do? (➕ add command, ➖ remove command in channel, ☠ delete command, ❌ abort)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var addStep = new ConfigurationStep("What kind of post do you want to add? (💌 embed, 📖 textpost, ✅ nothing further)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+
+            var aliasesStep = new ConfigurationStep("Please write the aliases you want for this command (comma separated), type 'none' for none", Interactive, Context, ConfigurationStep.StepType.Text, addStep);
+            var channelStep = new ConfigurationStep("Which channels should the command be active in? Please mention the channels with #", Interactive, Context, ConfigurationStep.StepType.Text, aliasesStep);
+
+            var commandStep = new ConfigurationStep("What should the name of the command be?", Interactive, Context, ConfigurationStep.StepType.Text, channelStep);
+            var textStep = new ConfigurationStep("Please post what the text of the text post should be", Interactive, Context, ConfigurationStep.StepType.Text, addStep);
+            var embedStep = new ConfigurationStep("What do you want to configure of your embedPost? (🤖 test current embed, 🖼 set a picture, 📖 set text, 💁 decide authorship, 🎨 choose color, ✅ nothing further)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var colorStep = new ConfigurationStep("What color do you want for your embed?", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var imageUrlStep = new ConfigurationStep("Please enter the url of the Image you want to set", Interactive, Context, ConfigurationStep.StepType.Text, embedStep);
+            var embedTextStep = new ConfigurationStep("Please enter the text you want to give your embed", Interactive, Context, ConfigurationStep.StepType.Text, embedStep);
+            var embedColorStep = new ConfigurationStep("Please choose a color you want to use for the embed", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var authorStep = new ConfigurationStep("Do you want to be marked as author? (✅ yes, ❌ no)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var deletionStep = new ConfigurationStep("React to the command in the channel you want to remove (❌ to abort, ◀ seek backward, ▶ seek forward)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var commandDeletionStep = new ConfigurationStep("React to the command you want to completely remove (❌ to abort, ◀ seek backward, ▶ seek forward)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            
+            var existingCommands = Global.FAQCommands.ToList();
+            var existingCommandChannels = new List<FAQCommandChannel>();
+            foreach(var comandElement in existingCommands)
+            {
+                if(comandElement.CommandChannels != null)
+                {
+                    foreach(var commandChannelelement in comandElement.CommandChannels)
+                    {
+                        existingCommandChannels.Add(commandChannelelement);
+                    }    
+                }
+                       
+            }
+
+            FAQCommand command = new FAQCommand();
+            List<FAQCommandChannel> commandChannels = new List<FAQCommandChannel>();
+            List<FAQCommandChannelEntry> entries = new List<FAQCommandChannelEntry>();
+            var builder = new FaqCommandChannelEntryBuilder();
+            builder.defaultValues();
+            List<IPaginatable> commandChannelPaginatable = existingCommandChannels.ConvertAll(x => (IPaginatable)x);
+            List<IPaginatable> commandPaginatable = existingCommands.ConvertAll(x => (IPaginatable)x);
+
+            var deletePagination = new CommandChannelPagination(deletionStep, configurationStep, commandChannelPaginatable);
+            deletePagination.setup();
+            deletePagination.actionOnIndex = (object obj) => 
+            {
+                var channel = obj as FAQCommandChannel;
+                using(var db = new Database())
+                {
+                    db.FAQCommandChannels.Remove(channel);
+                    db.SaveChanges();
+                }
+                existingCommands.Where(com => com.ID == channel.FAQCommandId).First().CommandChannels.Remove(channel);
+                commandChannelPaginatable.Remove(obj as IPaginatable);
+                return deletionStep;
+            };
+
+            var deleteCommandPagination = new CommandChannelPagination(commandDeletionStep, configurationStep, commandPaginatable);
+            deleteCommandPagination.setup();
+            deleteCommandPagination.actionOnIndex = (object obj) => 
+            {
+                var commandToDelete = obj as FAQCommand;
+                if(obj == null) return commandDeletionStep;
+                using(var db = new Database())
+                {
+                    db.FAQCommands.Remove(commandToDelete); 
+                    db.SaveChanges();
+                }
+
+                existingCommands.Remove(commandToDelete);
+                commandPaginatable.Remove(commandToDelete as IPaginatable);
+                return commandDeletionStep;
+            };
+
+            aliasesStep.TextCallback = (string text) => 
+            {
+                if(text != "none")
+                {
+                    command.Aliases = text;
+                }
+                else
+                {
+                    command.Aliases = "";
+                }
+                return true;
+            };
+    
+            commandStep.TextCallback = (string text) => 
+            {
+                command.Name = text;
+                return true;
+            };
+
+            imageUrlStep.TextCallback = (string text) => 
+            {
+                builder = builder.withImageUrl(text);
+                return true;
+            };
+
+            embedTextStep.TextCallback = (string text) => 
+            {
+                builder = builder.withText(text);
+                return true;
+            };
+
+            textStep.TextCallback = (string text) => 
+            {
+                builder = builder.withText(text);
+                var entry = builder.Build();
+                entry.IsEmbed = false;
+                entry.Position = (uint) entries.Count();
+                entries.Add(entry);
+                builder = new FaqCommandChannelEntryBuilder();
+                return true;
+            };
+
+            channelStep.TextCallback = (string text) => 
+            {
+                var channelIds = Regex.Matches(text, @"(?:\<#(?<channelId>\d{18})\>)*", 
+                RegexOptions.Multiline | 
+                RegexOptions.ExplicitCapture)
+                  .OfType<Match>()
+                  .Select (mt => mt.Groups["channelId"].Value);
+
+                foreach(var channelId in channelIds)
+                {
+                    if(channelId != string.Empty)
+                    {
+                        var channelIdLong = ulong.Parse(channelId);
+                        var channelObj = Global.FullChannels.Where(ch => ch.ChannelID == channelIdLong).DefaultIfEmpty(null).First();
+                        if(channelObj != null)
+                        {
+                            var commandChannel = new FAQCommandChannel();
+                            commandChannel.ChannelId = channelObj.ID;
+                            commandChannel.CommandChannelEntries = new List<FAQCommandChannelEntry>();
+                            commandChannels.Add(commandChannel);
+                        } 
+
+                    }
+                }
+                return true;
+            };
+
+            var addAction = new ReactionAction(new Emoji("➕"));
+            addAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = commandStep;
+                return false;
+            };
+
+            var deleteCommandChannelAction = new ReactionAction(new Emoji("➖"));
+            deleteCommandChannelAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = deletionStep;
+                return false;
+            };
+
+            var deleteCommandAction = new ReactionAction(new Emoji("☠"));
+            deleteCommandAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = commandDeletionStep;
+                return false;
+            };
+
+            var exitAction = new ReactionAction(new Emoji("❌"));
+            exitAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = null;
+                return false;
+            };
+
+            configurationStep.Actions.Add(addAction);
+            configurationStep.Actions.Add(deleteCommandChannelAction);
+            configurationStep.Actions.Add(deleteCommandAction);
+            configurationStep.Actions.Add(exitAction);
+
+            // blue
+            var blueChoice = new ReactionAction(new Emoji("📘"));
+            blueChoice.Action = (ConfigurationStep a) => 
+            {
+                builder.withHexColor(5614830);
+                a.Result = embedStep;
+                return false;
+            };
+
+            // red
+             var redChoice = new ReactionAction(new Emoji("📕"));
+            redChoice.Action = (ConfigurationStep a) => 
+            {
+                builder.withHexColor(14495300);
+                a.Result = embedStep;
+                return false;
+            };
+
+            // green
+             var greenChoice = new ReactionAction(new Emoji("📗"));
+            greenChoice.Action = (ConfigurationStep a) => 
+            {
+                builder.withHexColor(7844437);
+                a.Result = embedStep;
+                return false;
+            };
+
+            // yellow
+             var yellowChoice = new ReactionAction(new Emoji("📙"));
+            yellowChoice.Action = (ConfigurationStep a) => 
+            {
+                builder.withHexColor(16755763);
+                a.Result = embedStep;
+                return false;
+            };
+
+            // white
+             var whiteChoice = new ReactionAction(new Emoji("🔖"));
+            whiteChoice.Action = (ConfigurationStep a) => 
+            {
+                builder.withHexColor(14805229);
+                a.Result = embedStep;
+                return false;
+            };
+
+            // black
+             var blackChoice = new ReactionAction(new Emoji("⬛"));
+            blackChoice.Action = (ConfigurationStep a) => 
+            {
+                builder.withHexColor(2699059);
+                a.Result = embedStep;
+                return false;
+            };
+
+            colorStep.Actions.Add(blueChoice);
+            colorStep.Actions.Add(redChoice);
+            colorStep.Actions.Add(greenChoice);
+            colorStep.Actions.Add(yellowChoice);
+            colorStep.Actions.Add(whiteChoice);
+            colorStep.Actions.Add(blackChoice);
+
+            var imageUrlAction = new ReactionAction(new Emoji("🖼"));
+            imageUrlAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = imageUrlStep;
+                return false;
+            };
+
+            var embedTextAction = new ReactionAction(new Emoji("📖"));
+            embedTextAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = embedTextStep;
+                return false;
+            };
+
+            var chooseColorAction = new ReactionAction(new Emoji("🎨"));
+            chooseColorAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = colorStep;
+                return false;
+            };
+
+            var testEmbedAction = new ReactionAction(new Emoji("🤖"));
+            testEmbedAction.Action =  (ConfigurationStep a ) => 
+            {
+                // TODO delete the embed afterwards, we cant right now, because we would need to await it
+                Context.Channel.SendMessageAsync(embed: OnePlusBot.Helpers.Extensions.FaqCommandEntryToBuilder(builder.Build()).Build());
+                a.Result = embedStep;
+                return false;
+            };
+
+            var authorSettingAction = new ReactionAction(new Emoji("💁"));
+            authorSettingAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = authorStep;
+                return false;
+            };
+
+            var finishEmbedAction = new ReactionAction(new Emoji("✅"));
+            finishEmbedAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = addStep;
+                var entry = builder.Build();
+                entry.Position = (uint) entries.Count();
+                entry.IsEmbed = true;
+                entries.Add(entry);                
+                builder = new FaqCommandChannelEntryBuilder();
+                return false;
+            };
+
+            var abortEmbedAction = new ReactionAction(new Emoji("❌"));
+            abortEmbedAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = addStep;
+                return false;
+            };
+
+            embedStep.Actions.Add(testEmbedAction);
+            embedStep.Actions.Add(imageUrlAction);
+            embedStep.Actions.Add(embedTextAction);
+            embedStep.Actions.Add(chooseColorAction);
+            embedStep.Actions.Add(authorSettingAction);
+            embedStep.Actions.Add(finishEmbedAction);
+
+            var authorAgreeAction = new ReactionAction(new Emoji("✅"));
+            authorAgreeAction.Action = (ConfigurationStep a) => 
+            {
+                builder = builder.withAuthor(Context.Message.Author.Username);
+                builder = builder.withAuthorAvatarUrl(Context.Message.Author.GetAvatarUrl());
+                a.Result = embedStep;
+                return false;
+            };
+
+            var authorDenyAction = new ReactionAction(new Emoji("❌"));
+            authorDenyAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = embedStep;
+                // TODO do not hardcode
+                builder = builder.withAuthor("r/Oneplus");
+                builder = builder.withAuthorAvatarUrl("https://cdn.discordapp.com/avatars/426015562595041280/cab7dde68e8da9bcfd61842bd98e950b.png");
+                return false;
+            };
+
+            authorStep.Actions.Add(authorAgreeAction);
+            authorStep.Actions.Add(authorDenyAction);
+
+            var embedAction = new ReactionAction(new Emoji("💌"));
+            embedAction.Action = (ConfigurationStep a) => 
+            {
+                builder.defaultValues();
+                a.Result = embedStep;
+                return false;
+            };
+
+            var textAction = new ReactionAction(new Emoji("📖"));
+            textAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = textStep;
+                return false;
+            };
+
+            var commandFinished = new ReactionAction(new Emoji("✅"));
+            commandFinished.Action = (ConfigurationStep a ) => 
+            {
+
+                // run this in parallel, so it doesnt block, should be fast enough in order for any additional configuration to not happen yet from the user
+                Task.Run(() => {
+                    foreach(var entry in entries){
+                        foreach(var commandChannel in commandChannels){
+                            commandChannel.CommandChannelEntries.Add(entry.clone());
+                        }
+                    }
+                    command.CommandChannels = commandChannels;
+                    using (var db = new Database()){
+                        db.FAQCommands.Add(command);
+                        db.SaveChanges();
+                     }
+                    command = new FAQCommand();
+                    commandChannels = new List<FAQCommandChannel>();
+                    entries = new List<FAQCommandChannelEntry>();
+                });
+              
+                a.Result = configurationStep;
+                return false;
+            };
+
+            addStep.Actions.Add(embedAction);
+            addStep.Actions.Add(textAction);
+            addStep.Actions.Add(commandFinished);
+            
+            await configurationStep.SetupMessage();
+        }
+
+    }
+
+    public class CommandChannelPagination {
+        public ConfigurationStep step { get; set; }
+        public ConfigurationStep parent { get; set; }
+
+        public System.Collections.Generic.List<IPaginatable> elements { get; set;}
+        private int currentPage = 0;
+        private int elementOnPage = 5;
+
+        public Func<object, ConfigurationStep> actionOnIndex { get; set; } 
+
+
+        public CommandChannelPagination(ConfigurationStep step, ConfigurationStep parent, System.Collections.Generic.List<IPaginatable> elements)
+        {
+            this.step = step;
+            this.parent = parent;
+            this.elements = elements;
+        }
+
+        public void setup()
+        {
+            var prevAction = new ReactionAction(new Emoji("◀"));
+            prevAction.Action = (ConfigurationStep a )=> 
+            {
+                if(currentPage > 0)
+                {
+                    currentPage--;
+                }
+                a.Result = step;
+                return false;
+            };
+            var forwardAction = new ReactionAction(new Emoji("▶"));
+
+            forwardAction.Action = (ConfigurationStep a ) => 
+            {
+                if(currentPage < (elements.Count - 1) / elementOnPage)
+                {
+                    currentPage++;
+                }
+                a.Result = step;
+                return false;
+            };
+
+            Func<int, ConfigurationStep> processAtIndex = (int index) => 
+            {
+                index = currentPage * elementOnPage + index;
+                if(index < elements.Count)
+                {
+                    var channel = elements[index];
+                    return actionOnIndex(channel);
+                }
+                return null;
+            };
+            var firstAction = new ReactionAction(new Emoji("\u0031\u20e3"));
+            firstAction.Action = (ConfigurationStep a) => 
+            {
+                var otherStep = processAtIndex(0);
+                a.Result = otherStep ?? step;
+                return false;
+            };
+            var secondAction = new ReactionAction(new Emoji("\u0032\u20e3"));
+            secondAction.Action = (ConfigurationStep a) => 
+            {
+                var otherStep = processAtIndex(1);
+                a.Result = otherStep ?? step;
+                a.Result = step;
+                return false;
+            };
+            var thirdAction = new ReactionAction(new Emoji("\u0033\u20e3"));
+            thirdAction.Action = (ConfigurationStep a) => 
+            {
+                 var otherStep = processAtIndex(2);
+                a.Result = otherStep ?? step;
+                return false;
+            };
+            var fourthAction = new ReactionAction(new Emoji("\u0034\u20e3"));
+            fourthAction.Action = (ConfigurationStep a) => 
+            {
+                 var otherStep = processAtIndex(3);
+                a.Result = otherStep ?? step;
+                return false;
+            };
+            var fifthAction = new ReactionAction(new Emoji("\u0035\u20e3"));
+            fifthAction.Action = (ConfigurationStep a) => 
+            {
+                 var otherStep = processAtIndex(4);
+                a.Result = otherStep ?? step;
+                return false;
+            };
+
+            var abortDeletionAction = new ReactionAction(new Emoji("❌"));
+            abortDeletionAction.Action = (ConfigurationStep a) => 
+            {
+                a.Result = parent;
+                return false;
+            };
+          
+            step.Actions.Add(prevAction);
+            step.Actions.Add(firstAction);
+            step.Actions.Add(secondAction);
+            step.Actions.Add(thirdAction);
+            step.Actions.Add(fourthAction);
+            step.Actions.Add(fifthAction);
+            step.Actions.Add(forwardAction);
+            step.Actions.Add(abortDeletionAction);
+
+            step.beforeTextPosted = (ConfigurationStep a) => 
+            {
+                a.additionalPosts.Clear();
+                for(int i = currentPage * elementOnPage; i < currentPage * elementOnPage + elementOnPage && i < elements.Count; i++)
+                {
+                    var cmd = elements[i];
+                    a.additionalPosts.Add(cmd.display());
+                }
+                return false;
+            };
+        }
+    }
+}

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -140,342 +140,57 @@ namespace OnePlusBot.Modules
         [Summary("Answers frequently asked questions with a predetermined response.")]
         public async Task FAQAsync([Remainder] string parameter)
         {
-            try
+            var commands = Global.FAQCommands;
+            parameter = parameter.Trim();
+            var appropriateCommand = commands.Where(m => 
             {
-                switch (parameter.ToLower())
+                bool usingAlias = Array.Exists(m.IndividualAliases(), alias => alias.Equals(parameter));
+                return (m.Name == parameter || usingAlias);
+            });
+            if(appropriateCommand.Any())
+            {
+                var matchingCommand = appropriateCommand.First();
+                var contextChannel = Context.Channel;
+                if(matchingCommand.CommandChannels != null) 
                 {
-                    case "repairprices":
-                    case "repair":
-                    case "repairing":
-                    
-                        if (Context.Channel.Name == "general")
+                    var commandChannels = matchingCommand.CommandChannels.Where(cha => cha.Channel.ChannelID == contextChannel.Id);
+                    if(commandChannels.Any())
+                    {
+                        var entries = commandChannels.First().CommandChannelEntries.OrderBy(entry => entry.Position);
+                        if(entries.Any())
                         {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Repair prices for all OnePlus-devices: <https://www.oneplus.com/support/repair-pricing>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Repair prices for the OnePlus 7: <https://www.oneplus.com/support/repair-pricing/details?code=10>" + Environment.NewLine +
-                                             "Repair prices for the OnePlus 7 Pro: <https://www.oneplus.com/support/repair-pricing/details?code=11>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Repair prices for the OnePlus 6: <https://www.oneplus.com/support/repair-pricing/details?code=8>" + Environment.NewLine +
-                                             "Repair prices for the OnePlus 6T: <https://www.oneplus.com/support/repair-pricing/details?code=9>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Repair prices for the OnePlus 5: <https://www.oneplus.com/support/repair-pricing/details?code=5>" + Environment.NewLine +
-                                             "Repair prices for the OnePlus 5T: <https://www.oneplus.com/support/repair-pricing/details?code=7>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Repair prices for the OnePlus 3: <https://www.oneplus.com/support/repair-pricing/details?code=4>" + Environment.NewLine +
-                                             "Repair prices for the OnePlus 3T: <https://www.oneplus.com/support/repair-pricing/details?code=6>"));
-                        }
-                        else if (Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Repair prices for the OnePlus One: <https://www.oneplus.com/support/repair-pricing/details?code=1>" + Environment.NewLine +
-                                             "Repair prices for the OnePlus 2: <https://www.oneplus.com/support/repair-pricing/details?code=2>" + Environment.NewLine +
-                                             "Repair prices for the OnePlus X: <https://www.oneplus.com/support/repair-pricing/details?code=3>"));
-                        }
-                        break;
-                    case "blu_spark":
-                    case "bluspark":
-                        if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark XDA thread for OnePlus 7 Pro: <https://forum.xda-developers.com/oneplus-7-pro/development/kernel-t3944179/>" + Environment.NewLine +
-                                             "blu_spark XDA thread for OnePlus 7: <https://forum.xda-developers.com/oneplus-7/development/kernel-t3944855>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark XDA thread for OnePlus 6: <https://forum.xda-developers.com/oneplus-6/development/kernel-t3800965>" + Environment.NewLine +
-                                             "blu_spark XDA thread for OnePlus 6T: <https://forum.xda-developers.com/oneplus-6t/development/kernel-t3861123>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark XDA thread for OnePlus 5: <https://forum.xda-developers.com/oneplus-5/development/kernel-t3651933>" + Environment.NewLine +
-                                             "blu_spark XDA thread for OnePlus 5T: <https://forum.xda-developers.com/oneplus-5t/development/kernel-t3706295>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark XDA thread for OnePlus 3 and 3T: <https://forum.xda-developers.com/oneplus-3/oneplus-3--3t-cross-device-development/kernel-t3404970>"));
-                        }
-                        else if (Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark XDA thread for OnePlus X: <https://forum.xda-developers.com/oneplus-x/orig-development/kernel-t3250995>"));
-                        }
+                            foreach(var entry in entries)
+                            {
+                                if(!entry.IsEmbed)
+                                {
+                                    await Context.Channel.SendMessageAsync(entry.Text);
+                                }
+                                else 
+                                {
+                                    var embed = Extensions.FaqCommandEntryToBuilder(entry);
+                                    await Context.Channel.SendMessageAsync(embed: embed.Build());
+                                }
+                            }
+                        } 
                         else
                         {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Please perform your request in a device channel."));
+                            await Context.Channel.SendMessageAsync($"Channel has no posts configured for command {appropriateCommand.First().Name}.");
                         }
-                        break;
-                    case "twrp":
-                        if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark TWRP download link for OnePlus 7 and 7 Pro: <https://github.com/engstk/android_device_oneplus_guacamole_unified_TWRP/releases>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark TWRP download link for OnePlus 6: <https://github.com/engstk/android_device_oneplus_enchilada/releases>" + Environment.NewLine +
-                                             "blu_spark TWRP Download link for OnePlus 6T: <https://github.com/engstk/android_device_oneplus_fajita/releases>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("blu_spark TWRP download link for OnePlus 5 and 5T: <https://github.com/engstk/android_device_oneplus_cheeseburger/releases>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Official TWRP download link for OnePlus 3 and 3T: <https://twrp.me/oneplus/oneplusthree.html>"));
-                        }
-                        else if (Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Official TWRP download link for OnePlus X: <https://twrp.me/oneplus/oneplusx.html>" + Environment.NewLine +
-                                             "Official TWRP download link for OnePlus 2: <https://twrp.me/oneplus/oneplustwo.html>" + Environment.NewLine +
-                                             "Official TWRP download link for OnePlus One: <https://twrp.me/oneplus/oneplusone.html>"));
-                        }
-                        else
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Please perform your request in a device channel."));
-                        }
-                        break;
-                    case "unbrick":
-                    case "bricked":
-                    case "brick":
-                    case "unbricktool":
-                    
-                        if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Check out <#451373145010470912> for all Unbrick Tools for the OnePlus 7-series. Those also include the needed software and a manual")); // 451373145010470912 is channel ID of #useful-links in /r/oneplus server
-                        }
-                        else if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Check out <#451373145010470912> for all Unbrick Tools for the OnePlus 6 and 6T. Those also include the needed software and a manual"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Check out <#451373145010470912> for all Unbrick Tools for the OnePlus 5 and 5T. Those also include the needed software and a manual"));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Check out <#451373145010470912> for all Unbrick Tools for the OnePlus 3 and 3T. Those also include the needed software and a manual"));
-                        }
-                        else if (Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Check out <#451373145010470912> for all Unbrick Tools for legacy devices. Those also include the needed software and a manual"));
-                        }
-                        else
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Please perform your request in the correct device channel."));
-                        }
-                        break;
-                    case "root":
-                    case "magisk":
-                        if (Context.Channel.Name == "oneplus7-series" || Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Unlock bootloader using `fastboot oem unlock`. Boot temporarily into TWRP using `fastboot boot twrp.img` and select option `Install recovery to ramdisk`. Reboot your phone, come back to TWRP installed in ramdisk and then flash Magisk zip." + Environment.NewLine +
-                                             "As a reminder, Magisk does not have a website and the only place to get it is <https://github.com/topjohnwu/Magisk/releases>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t" || Context.Channel.Name == "oneplus3-3t" || Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Unlock bootloader using `fastboot oem unlock`. Flash magisk zip after installing TWRP (`fastboot flash recovery twrp.img` and `fastboot reboot`) " + Environment.NewLine +
-                                             "As a reminder, Magisk does not have a website and the only place to get it is <https://github.com/topjohnwu/Magisk/releases>"));
-                        }
-                        else
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Please refer to your device channel for detailed instructions."));
-                        }
-                        break;
-                    case "gcam":
-                    case "googlecam":
-                    case "googlecamera":
-                        if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Google Camera for OnePlus 7 & 7 Pro: <https://forum.xda-developers.com/oneplus-7-pro/themes/google-camera-op7-pro-t3944422>" + Environment.NewLine +
-                                             "For all device APKs, please visit: <https://www.celsoazevedo.com/files/android/google-camera>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Google Camera for OnePlus 6 & 6T: <https://forum.xda-developers.com/oneplus-6t/themes/app-oneplus-6-google-camera-port-t3862849>" + Environment.NewLine +
-                                             "For all device APKs, please visit: <https://www.celsoazevedo.com/files/android/google-camera>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Google Camera for OnePlus 5 & 5T: <https://forum.xda-developers.com/oneplus-5/themes/google-camera-hdr-t3655215>" + Environment.NewLine +
-                                             "For all device APKs, please visit: <https://www.celsoazevedo.com/files/android/google-camera>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Google Camera for 3 & 3T: <https://forum.xda-developers.com/oneplus-3/how-to/modded-google-camera-hdr-60fps-video-t3658552>" + Environment.NewLine +
-                                             "For all device APKs, please visit: <https://www.celsoazevedo.com/files/android/google-camera>"));
-                        }
-                        else if (Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Google Camera only supports 64 bit devices. Sorry."));
-                        }
-                        else
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("For all device APKs, please visit: <https://www.celsoazevedo.com/files/android/google-camera>"));
-                        }
-                        break;
-                    case "oxygenos":
-                    case "oosmirror":
-                    case "oos":
-                    case "ota":
-                    case "rom":
-                        if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("OnePlus 7 Pro mirrors for official OxygenOS: <https://forums.oneplus.com/threads/oneplus-7-pro-5g-rom-ota-oxygen-os-repo-of-oxygen-os-builds.1033129/>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("OnePlus 6 mirrors for official OxygenOS: <https://forums.oneplus.com/threads/oneplus-6-rom-ota-oxygen-os-mirrors-for-official-oxygen-os-roms-and-ota-updates.835607>" + Environment.NewLine +
-                                             "OnePlus 6T mirrors unavailable. Please use <https://www.oneplus.com/support/softwareupgrade/details?code=9>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("OnePlus 5 mirrors for official OxygenOS: <https://forums.oneplus.com/threads/oneplus-5-rom-ota-oxygen-os-mirrors-for-official-oxygen-os-roms-and-ota-updates.556580>" + Environment.NewLine +
-                                             "OnePlus 5T mirrors for official OxygenOS: <https://forums.oneplus.com/threads/oneplus-5t-rom-ota-oxygen-os-mirrors-for-official-oxygen-os-roms-and-ota-updates.686610>"));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("OnePlus 3T mirrors unavailable. Please use <https://www.oneplus.com/support/softwareupgrade/details?code=6>" + Environment.NewLine +
-                                             "OnePlus 3 mirrors for official OxygenOS: <https://forums.oneplus.com/threads/latest-3-2-4-oneplus-3-mirrors-for-official-oxygen-os-roms-and-ota-updates.450783>"));
-                        }
-                        else if (Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("OnePlus X mirrors unavailable. Please use <https://www.oneplus.com/support/softwareupgrade/details?code=3>" + Environment.NewLine +
-                                             "OnePlus 2 mirrors for official OxygenOS: <https://forum.xda-developers.com/oneplus-2/general/rom-mirrors-official-oxygen-os-roms-ota-t3209863>" + Environment.NewLine +
-                                             "OnePlus One mirrors unavailable. Please use <https://www.oneplus.com/support/softwareupgrade/details?code=1>"));
-                        }
-                        else
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Please refer to your device channel"));
-                        }
-                        break;
-                    case "edl":
-                    case "9008":
-                    case "9008mode":
-                        if (Context.Channel.Name == "oneplus7-series" || Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("To enter in Qualcomm EDL mode, you can use `adb reboot edl` or use any version of blu_spark TWRP based on TWRP 3.3.0 or later by clicking on `Reboot to EDL`. An alternative way is using `reboot edl` command in a rooted terminal emulator on your device. You can also power off your device, wait 10 seconds and maintain volume up and down keys." + Environment.NewLine +
-                                             "If you want to exit EDL mode, maintain power button during at least 10 seconds " + Environment.NewLine +
-                                             "You can use a generic USB-C cable however, OnePlus official cable are preferable"));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t" || Context.Channel.Name == "oneplus3-3t" || Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("To enter in Qualcomm EDL mode, you can use `adb reboot edl` or use any version of blu_spark TWRP based on TWRP 3.3.0 or later by clicking on `Reboot to EDL`. You can also power off your device, wait 10 seconds and maintain volume up keys" + Environment.NewLine +
-                                             "If you want to exit EDL mode, maintain power button during at least 10 seconds " + Environment.NewLine +
-                                             "You can use a generic USB-C cable however, OnePlus official cable are preferable"));
-                        }
-                        break;
-                    case "sahara":
-                    case "saharaerror":
-                    case "saharacommunication":
-                    case "saharacommunicationfailed":
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("If when using msm tool you have the error `Sahara communication failed`, follow this procedure to get rid of it." + Environment.NewLine +
-                                             "Press Stop button in MSM tool interface" + Environment.NewLine +
-                                             "Unplug your phone, maintain power button and any volume button to get it out of EDL mode until you feel a vibration." + Environment.NewLine +
-                                             "Wait 15 seconds." + Environment.NewLine +
-                                             "Maintain power button for 10 seconds." + Environment.NewLine +
-                                             "Get back in EDL mode, plug your phone to your computer, click on Enum button and click on Start button"));
-                        }
-                        break;
-                    case "whiteled":
-                    case "qualcommdiagnostics":
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("If you have a persistent white LED while trying to boot your phone and a black screen, it means that your device is stuck in Qualcomm Diagnostics mode." + Environment.NewLine +
-                                             "You can turn off your phone by maintaining power button during at least 10 seconds and then use MSM tool to recover it to a working state" + Environment.NewLine +
-                                             "To use MSM tool, you will need to enter in EDL mode. Information on how to do so can be obtained by sending the command `;faq edl`"));
-                        }
-                        break;
-                    case "smt":
-                    case "smtdownloadmode":
-                        if (Context.Channel.Name == "oneplus7-series" || Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("If you're reading this, stop what you are doing. Please." + Environment.NewLine +
-                                             "The reason why aftersales support of OnePlus use Upgrade Mode in MSM tool during remote assistance sessions rather than SMT mode is that it is meant for factory only as it wipes NV (non volatile) items such as IMEI (source <https://forum.xda-developers.com/showpost.php?p=77937552&postcount=90>)" + Environment.NewLine +
-                                             "You will also lose your Widevine L1 certificate."));
-                        }
-                        else if (Context.Channel.Name == "oneplus5-5t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("If you're reading this, stop what you are doing. Please." + Environment.NewLine +
-                                             "The reason why aftersales support of OnePlus use Upgrade Mode in MSM tool during remote assistance sessions rather than SMT mode is that it is meant for factory only as it wipes NV (non volatile) items such as IMEI (source <https://forum.xda-developers.com/showpost.php?p=77937552&postcount=90>)." + Environment.NewLine +
-                                             "You will also lose your Widevine L1 certificate (if your device is one of the units released before march 2018 with Widevine level being L3 and that you bothered sending your device back to OnePlus to get it updated to L1). Devices manufactured after March 2018 should have L1 certificate out of the box."));
-                        }
-                        else if (Context.Channel.Name == "oneplus3-3t" || Context.Channel.Name == "legacy")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("If you're reading this, stop what you are doing. Please." + Environment.NewLine +
-                                             "The reason why aftersales support of OnePlus use Upgrade Mode in MSM tool during remote assistance sessions rather than SMT mode is that it is meant for factory only as it wipes NV (non volatile) items such as IMEI (source <https://forum.xda-developers.com/showpost.php?p=77937552&postcount=90>)"));
-                        }
-                        break;
-                    case "qpreview":
-                    case "qbeta":
-                    case "qdevpreview":
-                    case "androidqpreview":
-                        if (Context.Channel.Name == "oneplus6-6t")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Android Q Dev Preview is now available to download for OnePlus 6 and 6T (source <https://forums.oneplus.com/threads/android-q-developer-preview-3-for-oneplus-6-and-6t.1076551/> )" + Environment.NewLine +
-                                             "Direct download link for OnePlus 6: <https://oxygenos.oneplus.net/OnePlus6Oxygen_22_OTA_003_all_1907120020_wipe_ae2a3b38959345b1.zip>" + Environment.NewLine +
-                                             "Direct download link for OnePlus 6T: <https://oxygenos.oneplus.net/OnePlus6TOxygen_34_OTA_003_all_1907120039_wipe_d9154a280c58444c.zip>" + Environment.NewLine +
-                                             "Place the relevant zip at the root of the system storage of your phone and use local update feature (Settings --> System --> System Updates --> click on the wheel) to update to Android Q dev preview." + Environment.NewLine +
-                                             "If you want to rollback to stable release of Android Pie, use again local update feature with these zips <https://oxygenos.oneplus.net/fulldowngrade_wipe_MSM_17819_181025_2315_user_MP1_release.zip> (for OP6) / <https://oxygenos.oneplus.net/Fulldowngrade_wipe_18801_181024_2027_user_MP2_release.zip> (for OP6T)" + Environment.NewLine +
-                                              Environment.NewLine +
-                                             "**WARNING**: T-Mobile OP6T converted users can flash Q Preview but will have to use MSM tool to recover their device if they wish to downgrade as the rollback zip provided by OnePlus will lead to a device mismatch according to reports on XDA forums (sources <https://forum.xda-developers.com/showpost.php?p=79482702&postcount=2295> and <https://forum.xda-developers.com/showpost.php?p=79483602&postcount=57> )"));
-                        }
-                        else if (Context.Channel.Name == "oneplus7-series")
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Android Q Dev Preview is now available to download for OnePlus 7 and 7 Pro (source <https://forums.oneplus.com/threads/android-q-developer-preview-4-for-oneplus-7-pro-and-7.1086050/> )" + Environment.NewLine +
-                                             "Direct download link for OnePlus 7: <https://oxygenos.oneplus.net/OnePlus7Oxygen_13.X.04_OTA_004_all_1908020007_38a5137d9f554eac.zip>" + Environment.NewLine +
-                                             "Direct download link for OnePlus 7 Pro: <https://oxygenos.oneplus.net/OnePlus7ProOxygen_13.X.04_OTA_004_all_1908020003_726196c3b79b4f85.zip>" + Environment.NewLine +
-                                             "Place the relevant zip at the root of the system storage of your phone and use local update feature (Settings --> System --> System Updates --> click on the wheel) to update to Android Q dev preview." + Environment.NewLine +
-                                             "If you want to rollback to stable release of Android Pie, use again local update feature with these zips <https://oxygenos.oneplus.net/fulldowngrade_wipe_MSM_18857_190505_1527_user.zip> (for OP7) / <https://oxygenos.oneplus.net/Fulldowngrade_wipe_18821_190425_0253_user_fix_revision_MP_release.zip> (for OP 7 Pro)" + Environment.NewLine +
-                                              Environment.NewLine +
-                                             "**WARNING**: T-Mobile OP 7 Pro converted users can flash Q Preview but will have to use MSM tool to recover their device if they wish to downgrade as the rollback zip provided by OnePlus will lead to a device mismatch.)"));
-                        }
-                        break;
-                    case "softwaremaintenanceschedule":
-                    case "updateschedule":
-                    case "updatewhen":
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("If you want to skip the incremental roll-out from OnePlus, you can use Oxygen Updater to receive updates quicker: https://play.google.com/store/apps/details?id=com.arjanvlek.oxygenupdater. OnePlus software maintenance schedule is described at <https://forums.oneplus.com/threads/oneplus-software-maintenance-schedule.862347/>"));
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithImageUrl("https://forums.oneplus.com/attachments/806308"));
-                        }
-                        break;
-                    case "adb":
-                    case "fastboot":
-                    case "adbfastboot":
-                    case "adbpath":
-                    case "fastbootpath":
-                    case "adbfastbootpath":
-                    case "platformtools":
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("To use ADB and fastboot tools, download them from <https://dl.google.com/android/repository/platform-tools-latest-windows.zip> (source <https://developer.android.com/studio/releases/platform-tools> ) and unzip them. If you wish to add them to your PATH (meaning being able to use them without having to navigate to the folder they're stored first), search in Start Menu for `Environment variables` and click on `Modify system environment variables`. On the next window click on `Environment variables`. Go to `System variables`, select `Path` and click on `Edit`. Click on `New` and input the location of where you unzipped `platform-tools` folder."));
-                        }
-                        break;
-                    case "oneplusswitch":
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("You can use OnePlus Switch <https://play.google.com/store/apps/details?id=com.oneplus.backuprestore> to backup and restore your data. Most of applications data will be backed up as well." + Environment.NewLine +
-                                             "If you want to avoid data of a specific application to be restored, you can get in `MobileBackup --> App` in `opbackup` folder to delete the .tar file associated to the app (eg: `com.whatsapp.tar` for data of WhatsApp)"));
-                        }
-                        break;
-                    case "readback":
-                        {
-                            await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("You can use readback function of MSM tool to dump your device partitions. They will be stored at the root of your system drive and have .img as file extension. For that, get in EDL mode, open MSM tool, press F8, tick partitions you want to dump, input `oneplus` as password, press `ok` and click on Readback button" + Environment.NewLine +
-                                             "Dumped partitions are flashable by fastboot." + Environment.NewLine +
-                                             "Do **NOT** share the following partitions: `dynamic_nvbk.bin`, `static_nvbk.bin`, `misc.bin`, `keystore.bin`, `config.bin`, `devinfo.bin` and `devcfg.mbn` as they contain informations such as your IMEI and your MAC adress (source <https://forum.xda-developers.com/showpost.php?p=78229476&postcount=96> )."));
-                        }
-                        break;
-                    //placeholder for any new FAQ entry that might be added in the future
-                    default:
-                        await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription("Supported FAQ commands are: repairprices, bluspark, googlecamera, oxygenos, unbrick, edl, magisk, root, qualcommdiagnostics, smt, qpreview, updateschedule, adbfastbootpath, saharacommunicationfailed, oneplusswitch, readback" + Environment.NewLine + 
-                                         "Mind that some commands can only be used in specific (device)channels"));
-                        break;
+                    }
+                    else
+                    {
+                         await Context.Channel.SendMessageAsync($"Channel has no response configured for command {appropriateCommand.First().Name}.");
+                    }
                 }
+                else 
+                {
+                    await Context.Channel.SendMessageAsync($"Channel has no response configured for command {appropriateCommand.First().Name}.");
+                }
+                
             }
-            catch (Exception ex)
+            else 
             {
-                await Context.Channel.EmbedAsync(new EmbedBuilder().WithColor(9896005).WithDescription(ex.Message));
+                await Context.Channel.SendMessageAsync(" command not found");
             }
         }
     }

--- a/src/OnePlusBot/OnePlusBot.csproj
+++ b/src/OnePlusBot/OnePlusBot.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="2.2.1-preview1-final" />
     <PackageReference Include="runtime.linux-x64.CoreCompat.System.Drawing" Version="1.0.0-beta009" />
     <PackageReference Include="runtime.osx.10.10-x64.CoreCompat.System.Drawing" Version="5.8.64" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="2.2.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Added dynamical faq commands, which can be configured within the bot and stored in the database, currently only addition and removal is supported.

The command to trigger the configuration is `;configurefaq` and the command to reload the configuration is `;reloaddb`.
The commands have the following features:

- name (no uniqueness check currently) this creates the possibility to define different responses for the same name
- aliases for each command
- define the channel a command is active in

The posts which the command consists of can be a text post or an embed. The configuration for an embed includes color, author, text, picture. A command can trigger multiple of these posts.

Further improvements, will be handled in separate PR and issues.