### PR TITLE
New additions to the warnings display

### DIFF
--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -357,7 +357,6 @@ namespace OnePlusBot.Modules
         private IGuildUser _user;
         private int _total;
         private int _index;
-        private int _indTotal;
         
         private async Task OnReactionAdded(Cacheable<IUserMessage, ulong> user, ISocketMessageChannel channel, SocketReaction reaction)
         {
@@ -457,20 +456,19 @@ namespace OnePlusBot.Modules
             using (var db = new Database())
             {
                 IQueryable<WarnEntry> warnings = db.Warnings;
-                IQueryable<WarnEntry> individualWarnings = db.Warnings;
+                IQueryable<WarnEntry> individualWarnings;
                 
                 if (user != null)
                     warnings = warnings.Where(x => x.WarnedUserID == user.Id);
 
                 _total = warnings.Count();
 
-                individualWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id);
-                _indTotal = individualWarnings.Count();
-
                 if (!requestee.Roles.Any(x => x.Name == "Staff"))
                 {
+                    individualWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id);
+                    int indTotal = individualWarnings.Count();
 
-                    await ReplyAsync($"You have {_indTotal} active warnings.");
+                    await ReplyAsync($"You have {indTotal} active warnings.");
 
                     return;
                 }


### PR DESCRIPTION
* Instead of warning # in the global list showing the number in order of the list it shows the Case ID for easier deletion
* ;warnings for non staff now shows their active warnings.

** THESE CHANGES ARE NOT FINAL