### PR TITLE
FAQ entries per channel and showing available commands feature

### DIFF
--- a/src/OnePlusBot/Data/Models/FaqCommandChannelEntry.cs
+++ b/src/OnePlusBot/Data/Models/FaqCommandChannelEntry.cs
@@ -8,7 +8,6 @@ namespace OnePlusBot.Data.Models
     [Table("FAQCommandChannelEntry")]
     public class FAQCommandChannelEntry
     {
-       
 
         [Key]
         [Column("entry_id", Order=0)]
@@ -29,7 +28,7 @@ namespace OnePlusBot.Data.Models
         [Column("position")]
         public uint Position { get; set; }
 
-        [Column("command_channel_id")]
+        [Column("command_channel_id_reference")]
         public uint CommandChannelId { get; set; }
 
         [Column("author")]
@@ -55,7 +54,17 @@ namespace OnePlusBot.Data.Models
             clone.Text = Text;
             return clone;
         }
-
+        
+        public bool Equals(FAQCommandChannelEntry other){
+            if(this == other) return true;
+            if(this.HexColor != other.HexColor) return false;
+            if(this.Text != other.Text) return false;
+            if(this.IsEmbed != other.IsEmbed) return false;
+            if(this.Author != other.Author)  return false;
+            if(this.AuthorAvatarUrl != other.AuthorAvatarUrl) return false;
+            if(this.ImageURL != other.ImageURL) return false;
+            return true;
+        }
 
     }
 }


### PR DESCRIPTION
This PR makes the parameter for the FAQ command optional, if you omit it, you see the currently available commands for the channel.
If you type an unknown command, it will respond with the currently available commands.

This also brings the feature of defining different responses for the same command in different channels.
You can use this feature by 'adding' a command and defining the same name. When you do that, you can *add* aliases to the command and *add* channels this command is active in.

If you click the `✅ nothing further` reaction when you get prompted for the posts the following will happen.
It will check if all the currently configured posts for the command are the same, if not, the user gets prompted which command from which channel he wants to use, if they are the same, the new command will be set to be the same as the others.
The user then can add *additional* posts to the existing posts which will be only valid for the channels selected at the start.

If you do not click the `✅ nothing further` reaction, but define posts on your own, nothing from other channels will be taken, and you can define the post as you would normally.

This code change also includes a change to a column of a table, so that needs to be changed, before this change is deployed.