### PR TITLE
fixed handling of deafening and muting

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -593,6 +593,23 @@ namespace OnePlusBot.Base
 
         private async Task UserChangedVoiceState(SocketUser user, SocketVoiceState oldState, SocketVoiceState newState)
         {
+
+            if(oldState.VoiceChannel != null && newState.VoiceChannel != null)
+            {
+                if(oldState.VoiceChannel.Id == newState.VoiceChannel.Id)
+                {
+                    return;
+                }
+            }
+
+            if(newState.VoiceChannel == null)
+            {
+                if(newState.IsDeafened)
+                {
+                    return;
+                }
+            }
+
             var bot = Global.Bot;
             var guild = bot.GetGuild(Global.ServerID);
             


### PR DESCRIPTION
The discord API handles deafening a bit weird. When you deafen, you get a null voice channel.
The event for voice state changed is also fired, when you mute, this this code fix adapts the code accordingly.