### PR TITLE
Added changed date to individual FAQ entries to track how up do date this information might be

### DIFF
--- a/src/OnePlusBot/Data/Models/FaqCommandChannelEntry.cs
+++ b/src/OnePlusBot/Data/Models/FaqCommandChannelEntry.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
 using System.Collections.Generic;
+using System;
 
 namespace OnePlusBot.Data.Models
 {
@@ -38,6 +39,10 @@ namespace OnePlusBot.Data.Models
         public string AuthorAvatarUrl { get; set; }
 
 
+        [Column("changed_date")]
+        public DateTime ChangedDate { get; set; }
+
+
         [ForeignKey("CommandChannelId")]
         public virtual FAQCommandChannel FAQCommandChannel { get; set; }
 
@@ -52,6 +57,9 @@ namespace OnePlusBot.Data.Models
             clone.ImageURL = ImageURL;
             clone.IsEmbed = IsEmbed;
             clone.Text = Text;
+            // I think setting the changed date to now is fine, because we use the cloning, when we use an entry from an already existing channel
+            // that means in the process of a creating an entry, and with that we basically say 'this is right'
+            clone.ChangedDate = DateTime.Now;
             return clone;
         }
         

--- a/src/OnePlusBot/Data/Models/FaqCommandChannelEntryBuilder.cs
+++ b/src/OnePlusBot/Data/Models/FaqCommandChannelEntryBuilder.cs
@@ -1,45 +1,62 @@
+using System;
 namespace OnePlusBot.Data.Models
 {
-    public class FaqCommandChannelEntryBuilder {
+    public class FaqCommandChannelEntryBuilder 
+    {
         FAQCommandChannelEntry entry = new FAQCommandChannelEntry();
 
-        public FaqCommandChannelEntryBuilder withText(string value){
+        public FaqCommandChannelEntryBuilder withText(string value)
+        {
             entry.Text = value;
             return this;
         }
 
-        public FaqCommandChannelEntryBuilder withImageUrl(string value){
+        public FaqCommandChannelEntryBuilder withImageUrl(string value)
+        {
             entry.ImageURL = value;
             return this;
         }
 
-        public FaqCommandChannelEntryBuilder withAuthor(string value){
+        public FaqCommandChannelEntryBuilder withAuthor(string value)
+        {
             entry.Author = value;
             return this;
         }
 
-        public FaqCommandChannelEntryBuilder withHexColor(uint value){
+        public FaqCommandChannelEntryBuilder withHexColor(uint value)
+        {
             entry.HexColor = value;
             return this;
         }
 
-        public FaqCommandChannelEntryBuilder withAuthorAvatarUrl(string value){
+        public FaqCommandChannelEntryBuilder withAuthorAvatarUrl(string value)
+        {
             entry.AuthorAvatarUrl = value;
             return this;
         }
 
-        public FaqCommandChannelEntryBuilder withIsEmbed(bool value){
+        public FaqCommandChannelEntryBuilder withIsEmbed(bool value)
+        {
             entry.IsEmbed = value;
             return this;
         }
 
-        public FaqCommandChannelEntryBuilder defaultValues(){
-            this.withAuthor("r/Oneplus");
-            this.withAuthorAvatarUrl("https://cdn.discordapp.com/avatars/426015562595041280/cab7dde68e8da9bcfd61842bd98e950b.png");
+        public FaqCommandChannelEntryBuilder withChangedDate(DateTime changedDate)
+        {
+            entry.ChangedDate = changedDate;
             return this;
         }
 
-        public FAQCommandChannelEntry Build(){
+        public FaqCommandChannelEntryBuilder defaultValues()
+        {
+            this.withAuthor("r/Oneplus");
+            this.withAuthorAvatarUrl("https://cdn.discordapp.com/avatars/426015562595041280/cab7dde68e8da9bcfd61842bd98e950b.png");
+            this.withChangedDate(DateTime.Now);
+            return this;
+        }
+
+        public FAQCommandChannelEntry Build()
+        {
             return entry;
         }
     }

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -82,6 +82,7 @@ namespace OnePlusBot.Helpers
             if(entry.ImageURL != null){
                 faqEmbedEntry.WithImageUrl(entry.ImageURL);
             }
+            faqEmbedEntry.WithTimestamp(entry.ChangedDate);
             faqEmbedEntry.WithAuthor(entry.Author, entry.AuthorAvatarUrl);
 
             return faqEmbedEntry;

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -199,15 +199,19 @@ namespace OnePlusBot.Modules
                 {
                     if(text.ToUpper().Contains("ALL"))
                     {
-                        var channelCommands = existingCommands.Where(c => c.Name == command.Name).First();
+                        var channelCommands = existingCommands.Where(c => c.Name == command.Name).DefaultIfEmpty(null).First();
                         foreach(var channel in Global.FullChannels)
                         {
-                            var existingChannels = channelCommands.CommandChannels.Where(cch => cch.Channel?.ChannelID == channel.ChannelID);
-                            var channelAlreadyExists = existingChannels.Any();
-                            if(channelAlreadyExists)
+                            if(channelCommands != null)
                             {
-                                continue;
+                                var existingChannels = channelCommands.CommandChannels.Where(cch => cch.Channel?.ChannelID == channel.ChannelID);
+                                var channelAlreadyExists = existingChannels.Any();
+                                if(channelAlreadyExists)
+                                {
+                                    continue;
+                                }
                             }
+                           
                             var commandChannel = new FAQCommandChannel();
                             commandChannel.ChannelId = channel.ID;
                             commandChannel.CommandChannelEntries = new List<FAQCommandChannelEntry>();


### PR DESCRIPTION
This PR adds a column to the entry table which cannot be null, with a default value the current time.
It is not possible to configure the actual time when creating an entry, it just takes the current time stamp.
The value is stored for text posts as well, but not (yet) used for posting.
The value of the changed date column is then used for the timestamp of a particular embed.

This PR also fixes a bug with creating commands for all channels which was previously not known.