### PR TITLE
added attachment handling to news

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -207,7 +207,7 @@ namespace OnePlusBot.Base
             }
             catch(NullReferenceException ex)
             {
-                await channel.Guild.GetTextChannel(Global.Channels["modlog"]).SendMessageAsync(ex.ToString());
+                return;
             }
             // it was sometimes null
             if(deletedMessage == null)


### PR DESCRIPTION
If there is an attachment in the original message triggering the news, we will download that attachment and attach it to the newly created news post.
This also works when editing the news post, because you cannot edit the attachment, so it stays around.