### PR TITLE
added starboard functionality

### DIFF
--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -1,4 +1,6 @@
-﻿using System.Data.Common;
+﻿using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+using System.Data.Common;
 using Discord;
 using Discord.Addons.Interactive;
 using Discord.Commands;
@@ -15,6 +17,10 @@ namespace OnePlusBot.Base
 {
     public static class Core
     {
+
+        private static Collection<IReactionAction> AddReactionActions;
+
+        private static Collection<IReactionAction> RemoveReactionActions;
         public static async Task Main()
         {
             var services = BuildServices();
@@ -41,7 +47,19 @@ namespace OnePlusBot.Base
             t.Elapsed += new ElapsedEventHandler(OnTimerElapsed);
             t.Start();
 
+            FillReactionActions();
+
             await Task.Delay(-1);
+        }
+
+        private static void FillReactionActions()
+        {
+            AddReactionActions = new Collection<IReactionAction>();
+            RemoveReactionActions = new Collection<IReactionAction>();
+            AddReactionActions.Add(new AddRoleReactionAction());
+            AddReactionActions.Add(new StarboardAddedReactionAction());
+            RemoveReactionActions.Add(new RemoveRoleReactionAction());
+            RemoveReactionActions.Add(new StarboardRemovedReactionAction());
         }
 
         private static void OnTimerElapsed(object sender, ElapsedEventArgs e)
@@ -57,35 +75,13 @@ namespace OnePlusBot.Base
         {
             if (reaction.User.Value.IsBot)
                 return;
-
-            if (reaction.MessageId != Global.RoleManagerMessageId)
-                return;
-            
-            var dict = new Dictionary<string, string> //TODO: Change from string to emote and role IDs
+            IUserMessage msg = await cache.DownloadAsync();
+            foreach(IReactionAction action in AddReactionActions)
             {
-                { "1_", "OnePlus One" },
-                { "2_", "OnePlus 2" },
-                { "X_", "OnePlus X" },
-                { "3_", "OnePlus 3" },
-                { "3T", "OnePlus 3T" },
-                { "5_", "OnePlus 5" },
-                { "5T", "OnePlus 5T" },
-                { "6_", "OnePlus 6" },
-                { "6T", "OnePlus 6T" },
-                { "7_", "OnePlus 7" },
-                { "7P", "OnePlus 7 Pro" },
-                { "\x2753", "Helper" },
-                { "\xD83D\xDCF0", "News" }
-            };
-
-            if (dict.TryGetValue(reaction.Emote.Name, out string roleName))
-            {
-                var guild = ((IGuildChannel) channel).Guild;
-                var role = guild.Roles.FirstOrDefault(x => x.Name == roleName);
-                if (role != null)
+                if(action.ActionApplies(msg, channel, reaction))
                 {
-                    var user = (IGuildUser) reaction.User.Value;
-                    await user.AddRoleAsync(role);
+                    await action.Execute(msg, channel, reaction);
+                    break;
                 }
             }
         }
@@ -95,35 +91,13 @@ namespace OnePlusBot.Base
             if (reaction.User.Value.IsBot)
                 return;
             
-            if (reaction.MessageId != Global.RoleManagerMessageId)
-                return;
-            
-            var dict = new Dictionary<string, string> //TODO: Change from string to emote and role IDs // It won't work with the IDs, iirc. -Rith
+            IUserMessage msg = await cache.DownloadAsync();
+            foreach(IReactionAction action in RemoveReactionActions)
             {
-                { "1_", "OnePlus One" },
-                { "2_", "OnePlus 2" },
-                { "X_", "OnePlus X" },
-                { "3_", "OnePlus 3" },
-                { "3T", "OnePlus 3T" },
-                { "5_", "OnePlus 5" },
-                { "5T", "OnePlus 5T" },
-                { "6_", "OnePlus 6" },
-                { "6T", "OnePlus 6T" },
-                { "7_", "OnePlus 7" },
-                { "7P", "OnePlus 7 Pro" },
-                { "\x2753", "Helper" },
-                { "\xD83D\xDCF0", "News" }
-            };
-
-
-            if (dict.TryGetValue(reaction.Emote.Name, out string roleName))
-            {
-                var guild = ((IGuildChannel) channel).Guild;
-                var role = guild.Roles.FirstOrDefault(x => x.Name == roleName);
-                if (role != null)
+                if(action.ActionApplies(msg, channel, reaction))
                 {
-                    var user = (IGuildUser) reaction.User.Value;
-                    await user.RemoveRoleAsync(role);
+                    await action.Execute(msg, channel, reaction);
+                    break;
                 }
             }
         }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -205,7 +205,7 @@ namespace OnePlusBot.Base
             {
                 deletedMessage = await cacheable.GetOrDownloadAsync();
             }
-            catch(NullReferenceException ex)
+            catch(NullReferenceException)
             {
                 return;
             }

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -30,6 +30,10 @@ namespace OnePlusBot.Base
         public static List<FAQCommand> FAQCommands { get; set; }
 
         public static ulong CommandExecutorId { get; set; }
+
+        public static ulong StarboardStars { get; set; }
+
+        public static List<StarboardMessage> StarboardPosts { get; set; }
         
         public static string Token
         {
@@ -79,7 +83,8 @@ namespace OnePlusBot.Base
             Channels = new Dictionary<string, ulong>();
             FullChannels = new List<Channel>();
             Random = new Random();
-            NewsPosts = new Dictionary<ulong, ulong>();    
+            NewsPosts = new Dictionary<ulong, ulong>();  
+            StarboardPosts = new List<StarboardMessage>();  
             Roles = new Dictionary<string, ulong>();
             ProfanityChecks = new List<Regex>();
             FAQCommands = new List<FAQCommand>();
@@ -113,6 +118,19 @@ namespace OnePlusBot.Base
                     .First(x => x.Name == "rolemanager_message_id")
                     .Value;
 
+                StarboardStars = db.PersistentData
+                    .First(entry => entry.Name == "starboard_stars")
+                    .Value;
+
+                StarboardPosts.Clear();
+                if(db.StarboardMessages.Any())
+                {
+                    foreach(var post in db.StarboardMessages)
+                    {
+                        StarboardPosts.Add(post);
+                    }
+                }
+
                 ProfanityChecks.Clear();
                 if(db.ProfanityChecks.Any())
                 {
@@ -143,6 +161,8 @@ namespace OnePlusBot.Base
             public static IEmote FAIL = new Emoji("⚠");
             public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
             public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");
+
+            public static IEmote STAR = new Emoji("⭐");
         }
 
         public static DiscordSocketClient Bot { get; set;}

--- a/src/OnePlusBot/Base/IReactionAction.cs
+++ b/src/OnePlusBot/Base/IReactionAction.cs
@@ -1,0 +1,15 @@
+using System;
+using Discord;
+using Discord.Addons.Interactive;
+using Discord.Commands;
+using Discord.WebSocket;
+using System.Threading.Tasks;
+
+namespace OnePlusBot.Base
+{
+    public interface IReactionAction
+    {
+        Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction);
+        Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction);
+    }
+}

--- a/src/OnePlusBot/Base/RoleReactionAction.cs
+++ b/src/OnePlusBot/Base/RoleReactionAction.cs
@@ -1,0 +1,88 @@
+using System;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OnePlusBot.Base
+{
+    public class RemoveRoleReactionAction : IReactionAction
+    {
+        public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            return reaction.MessageId == Global.RoleManagerMessageId;
+        }
+        public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
+        {
+            var dict = new Dictionary<string, string> //TODO: Change from string to emote and role IDs
+            {
+                { "1_", "OnePlus One" },
+                { "2_", "OnePlus 2" },
+                { "X_", "OnePlus X" },
+                { "3_", "OnePlus 3" },
+                { "3T", "OnePlus 3T" },
+                { "5_", "OnePlus 5" },
+                { "5T", "OnePlus 5T" },
+                { "6_", "OnePlus 6" },
+                { "6T", "OnePlus 6T" },
+                { "7_", "OnePlus 7" },
+                { "7P", "OnePlus 7 Pro" },
+                { "\x2753", "Helper" },
+                { "\xD83D\xDCF0", "News" }
+            };
+
+            if (dict.TryGetValue(reaction.Emote.Name, out string roleName))
+            {
+                var guild = ((IGuildChannel) channel).Guild;
+                var role = guild.Roles.FirstOrDefault(x => x.Name == roleName);
+                if (role != null)
+                {
+                    var user = (IGuildUser) reaction.User.Value;
+                    await user.RemoveRoleAsync(role);
+                }
+            }
+            await Task.CompletedTask;
+        }
+    }
+
+    public class AddRoleReactionAction : IReactionAction
+    {
+        public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            return reaction.MessageId == Global.RoleManagerMessageId;
+        }
+        public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
+        {
+            var dict = new Dictionary<string, string> //TODO: Change from string to emote and role IDs
+            {
+                { "1_", "OnePlus One" },
+                { "2_", "OnePlus 2" },
+                { "X_", "OnePlus X" },
+                { "3_", "OnePlus 3" },
+                { "3T", "OnePlus 3T" },
+                { "5_", "OnePlus 5" },
+                { "5T", "OnePlus 5T" },
+                { "6_", "OnePlus 6" },
+                { "6T", "OnePlus 6T" },
+                { "7_", "OnePlus 7" },
+                { "7P", "OnePlus 7 Pro" },
+                { "\x2753", "Helper" },
+                { "\xD83D\xDCF0", "News" }
+            };
+
+            if (dict.TryGetValue(reaction.Emote.Name, out string roleName))
+            {
+                var guild = ((IGuildChannel) channel).Guild;
+                var role = guild.Roles.FirstOrDefault(x => x.Name == roleName);
+                if (role != null)
+                {
+                    var user = (IGuildUser) reaction.User.Value;
+                    await user.AddRoleAsync(role);
+                }
+            }
+            await Task.CompletedTask;
+        }
+    }
+}

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -1,0 +1,199 @@
+using System.Runtime.ConstrainedExecution;
+using System.Runtime.CompilerServices;
+using System.Data.Common;
+using System;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using OnePlusBot.Data;
+using OnePlusBot.Data.Models;
+
+namespace OnePlusBot.Base
+{
+    public class StarboardReactionAction : IReactionAction
+    {
+
+        protected ulong StarboardPostId;
+        protected bool TriggeredThreshold = false;
+        protected bool RelationAdded = false;
+        public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            return reaction.Emote.Equals(Global.OnePlusEmote.STAR) && message.Author.Id != reaction.UserId;
+        }
+        public virtual async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
+        {
+            this.TriggeredThreshold = false;
+            this.RelationAdded = false;
+            var guild = Global.Bot.GetGuild(Global.ServerID);
+            
+            var currentStarReaction = message.Reactions.Where(re => re.Key.Name == reaction.Emote.Name).DefaultIfEmpty().First();
+
+            var starboardChannelId = Global.Channels["starboard"];
+            var starboardChannel = guild.GetTextChannel(starboardChannelId);
+            var existingPostList = Global.StarboardPosts.Where(msg => msg.MessageId == message.Id);
+
+            var starCount = await this.GetTrueStarCount(message, currentStarReaction);
+            if(existingPostList.Any())
+            {
+                this.RelationAdded = true;
+                var existingPost = existingPostList.First();
+                var starboardChannelPostId = existingPost.StarboardMessageId;
+                this.StarboardPostId = starboardChannelPostId;
+                existingPost.Starcount = (uint) starCount;
+                using(var db = new Database())
+                {
+                    var post = db.StarboardMessages.Where(p => p.MessageId == message.Id).First();
+                    post.Starcount = (uint) starCount;
+                    db.SaveChanges();
+                }
+                var starboardChannelPost = await starboardChannel.GetMessageAsync(starboardChannelPostId) as IUserMessage;
+                if(starCount >= (int) Global.StarboardStars && starboardChannelPost != null )
+                {
+                    await starboardChannelPost.ModifyAsync(msg => msg.Content = GetStarboardMessage(message, currentStarReaction, reaction, starCount));
+                } 
+                else if(starboardChannelPost != null)
+                {
+                    await starboardChannelPost.DeleteAsync();
+                    Global.StarboardPosts.Remove(existingPost);
+                    using(var db = new Database())
+                    {
+                        var relationPosts = db.StarboardPostRelations.Where(post => post.MessageId == message.Id);
+                        db.StarboardPostRelations.RemoveRange(relationPosts);
+                        db.SaveChanges();
+                        var starboardMessage = db.StarboardMessages.Where(post => post.MessageId == message.Id).First();
+                        db.StarboardMessages.Remove(starboardMessage);
+                        db.SaveChanges();
+                    }
+                    this.TriggeredThreshold = true;
+                }
+            }
+            else
+            {   
+                if(starCount >= (int) Global.StarboardStars)
+                {
+                    var starboardMessage = await starboardChannel.SendMessageAsync(GetStarboardMessage(message, currentStarReaction, reaction, starCount), 
+                    embed: GetStarboardEmbed(message, currentStarReaction));
+                    using (var db = new Database())
+                    {
+                        var starboardMessageDto = new StarboardMessage();
+                        starboardMessageDto.MessageId = message.Id;
+                        starboardMessageDto.StarboardMessageId = starboardMessage.Id;
+                        starboardMessageDto.Starcount = (uint) starCount;
+                        starboardMessageDto.AuthorId = message.Author.Id;
+                        db.StarboardMessages.Add(starboardMessageDto);
+                        Global.StarboardPosts.Add(starboardMessageDto);
+                        db.SaveChanges();
+                    }
+                    this.TriggeredThreshold = true;
+                    this.StarboardPostId = starboardMessage.Id;
+                    this.RelationAdded = true;
+                } 
+                else
+                {
+                    this.RelationAdded = false;
+                }
+            }
+        }
+
+        private Embed GetStarboardEmbed(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> reactionInfo)
+        {
+            var builder =  new EmbedBuilder()
+                .WithColor(9896005)
+                .WithAuthor(author => author
+                    .WithIconUrl(message.Author.GetAvatarUrl())
+                    .WithName(message.Author.Username)
+                    )
+                    
+                .WithDescription(message.Content)
+                .AddField(fb => fb
+                    .WithName("Original")
+                    .WithValue(OnePlusBot.Helpers.Extensions.GetMessageUrl(Global.ServerID, message.Channel.Id, message.Id, "jump"))
+                    )
+                .WithTimestamp(message.CreatedAt);
+            if(message.Attachments.Count > 0)
+            {
+                builder = builder.WithImageUrl(message.Attachments.First().ProxyUrl);
+            }
+
+            return builder.Build();
+        }
+
+        private string GetStarboardMessage(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> reactionInfo, IReaction reaction, int starCount)
+        {
+            return $"{reaction.Emote.Name} {starCount} <#{message.Channel.Id}> ID: {message.Id}"; 
+        }
+
+        private async Task<int> GetTrueStarCount(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> starReaction)
+        {
+            var reactions = message.GetReactionUsersAsync(Global.OnePlusEmote.STAR, starReaction.Value.ReactionCount);
+            var validReactions = 0;
+            await reactions.ForEachAsync(collection =>
+            {
+                foreach(var user in collection)
+                {
+                    if(user.Id != message.Author.Id)
+                    {
+                        validReactions += 1;
+                    }
+                }
+            });
+            return validReactions;
+        }
+    }
+
+    public class StarboardAddedReactionAction : StarboardReactionAction 
+    {
+         public override async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+         {
+           
+            await base.Execute(message, channel, reaction);
+            using (var db = new Database())
+            {  
+                if(this.TriggeredThreshold)
+                {
+                    var currentStarReaction = message.Reactions.Where(re => re.Key.Name == reaction.Emote.Name).DefaultIfEmpty().First();
+                    var reactions = message.GetReactionUsersAsync(Global.OnePlusEmote.STAR, currentStarReaction.Value.ReactionCount);
+                    await reactions.ForEachAsync(collection =>
+                    {
+                        foreach(var user in collection)
+                        {
+                            var starerRelation = new StarboardPostRelation();
+                            starerRelation.UserId = user.Id;
+                            starerRelation.MessageId = message.Id;
+                            db.StarboardPostRelations.Add(starerRelation);
+                        }
+                    });
+                    
+                }
+                else if(this.RelationAdded)
+                {
+                    var starerRelation = new StarboardPostRelation();
+                    starerRelation.UserId = reaction.UserId;
+                    starerRelation.MessageId = message.Id;
+                    db.StarboardPostRelations.Add(starerRelation);
+                }
+                db.SaveChanges();
+            }
+         }
+    }
+
+    public class StarboardRemovedReactionAction : StarboardReactionAction
+    {
+         public override async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+         {
+            await base.Execute(message, channel, reaction);
+            using (var db = new Database())
+            {
+                var existing = db.StarboardPostRelations.Where(rel => rel.MessageId == message.Id && rel.UserId == message.Author.Id)
+                .DefaultIfEmpty(null).First();
+                if(existing != null)
+                {
+                    db.StarboardPostRelations.Remove(existing);
+                }
+            }
+         }
+    }
+}

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -27,6 +27,10 @@ namespace OnePlusBot.Data
 
         public DbSet<Mute> Mutes {get; set; }
 
+        public DbSet<StarboardMessage> StarboardMessages { get; set; }
+
+        public DbSet<StarboardPostRelation> StarboardPostRelations { get; set; }
+
         // TODO needs to be replaced with proper dependency injection
         public static readonly LoggerFactory LoggerFactory
         = new LoggerFactory(new[] {new ConsoleLoggerProvider((_, __) => true, true)});
@@ -57,6 +61,8 @@ namespace OnePlusBot.Data
 
         protected override void OnModelCreating(ModelBuilder modelBuilder)
         {
+              modelBuilder.Entity<StarboardPostRelation>().HasKey(c => new { c.MessageId, c.UserId });
         }
+
     }
 }

--- a/src/OnePlusBot/Data/Models/Mute.cs
+++ b/src/OnePlusBot/Data/Models/Mute.cs
@@ -5,7 +5,7 @@ using Discord;
 
 namespace OnePlusBot.Data.Models
 {
-      [Table("Mutes")]
+    [Table("Mutes")]
     public class Mute
     {
         [Key]

--- a/src/OnePlusBot/Data/Models/StarboardMessage.cs
+++ b/src/OnePlusBot/Data/Models/StarboardMessage.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("StarboardMessages")]
+    public class StarboardMessage
+    {        
+        [Key]
+        [Column("message_id")]
+        public ulong MessageId { get; set; }
+
+        [Column("starboard_message_id")]
+        public ulong StarboardMessageId { get; set; }
+
+        [Column("star_count")]
+        public uint Starcount { get; set; }
+
+        [Column("author_id")]
+        public ulong AuthorId { get; set; }
+
+    }
+
+}

--- a/src/OnePlusBot/Data/Models/StarboardPostRelation.cs
+++ b/src/OnePlusBot/Data/Models/StarboardPostRelation.cs
@@ -1,0 +1,16 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("StarboardPostRelations")]
+    public class StarboardPostRelation
+    {
+        [Column("user_id")]
+        public ulong UserId { get; set; }
+
+        [Column("message_id")]
+        public ulong MessageId { get; set; }
+    }
+}

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -87,5 +87,22 @@ namespace OnePlusBot.Helpers
 
             return faqEmbedEntry;
         }
+
+        public static string GetChannelUrl(ulong serverId, ulong channelId, string displayName)
+        {
+            const string discordUrl = "https://discordapp.com/channels/{0}/{1}/";
+            return $"[{ displayName }]({string.Format(discordUrl, serverId, channelId)})";
+        }
+
+        public static string GetMessageUrl(ulong serverId, ulong channelId, ulong messageId, string displayName)
+        {
+            const string discordUrl = "https://discordapp.com/channels/{0}/{1}/{2}";
+            return $"[{ displayName }]({string.Format(discordUrl, serverId, channelId, messageId)})";
+        }
+
+        public static IUser GetUserById(ulong userId)
+        {
+            return Global.Bot.GetGuild(Global.ServerID).GetUser(userId); 
+        }
     }
 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -515,5 +515,30 @@ namespace OnePlusBot.Modules
             Global.LoadGlobal();
             return CustomResult.FromSuccess();
         }
+
+        [
+            Command("setstars"),
+            Summary("sets the amount required to appear on the starboard"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> SetStars(string input)
+        {
+            ulong amount = 0;
+            await Task.Delay(25);
+            if(ulong.TryParse(input, out amount) && amount > 0){
+                using (var db = new Database()){
+                    var point = db.PersistentData.First(entry => entry.Name == "starboard_stars");
+                    point.Value = amount;
+                    db.SaveChanges();
+                }
+                Global.StarboardStars = amount;
+                return CustomResult.FromSuccess();
+            } 
+            else
+            {
+                return CustomResult.FromError("whole numbers > 0 only");
+            }
+           
+        }
     }
 }


### PR DESCRIPTION
For the starboard the amount of stars can be configured. This amount of stars needs to be reached, in order for the post to appear on the starboard. The stars by the poster of the message do not count.

When a message fits these conditions, it will appear on the starboard like [this](https://imgur.com/zuGLN24.png). This post will be updated, when the amount of stars change, and the post will (currently) be removed, in case the configured threshold is not reached anymore.

The amount of stars required can be configure with the command `;setstars`, and needs to be > 0. This command is bound to the staff role. Changing this will not retroactively remove posts from the starboard, but only apply to future posts or when posts are updated.

The starboard feature also includes statistics about the starboard messages. With the command `;starstats` you get a listing similar [this](https://imgur.com/2bYU6Qc.png). 
The first section contains links to the posts *on* the starboard.
The second section only considers those messages, which actually reached the starboard.

This PR also includes a slight refactor how the reaction added/removed events are handled and configured.