### PR TITLE
Various fixes and improvements for small issues

### DIFF
--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -1,7 +1,4 @@
-﻿using System.Runtime.CompilerServices;
-using System.ComponentModel.Design;
-using System.Net.Mime;
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Discord;
@@ -32,6 +29,9 @@ namespace OnePlusBot.Base
         public static ulong CommandExecutorId { get; set; }
 
         public static ulong StarboardStars { get; set; }
+
+        public static ulong Level2Stars { get; set; }
+        public static ulong Level3Stars { get; set; }
 
         public static List<StarboardMessage> StarboardPosts { get; set; }
         
@@ -122,6 +122,14 @@ namespace OnePlusBot.Base
                     .First(entry => entry.Name == "starboard_stars")
                     .Value;
 
+                Level2Stars = db.PersistentData
+                    .First(entry => entry.Name == "level_2_stars")
+                    .Value;
+
+                Level3Stars = db.PersistentData
+                    .First(entry => entry.Name == "level_3_stars")
+                    .Value;
+
                 StarboardPosts.Clear();
                 if(db.StarboardMessages.Any())
                 {
@@ -163,6 +171,9 @@ namespace OnePlusBot.Base
             public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");
 
             public static IEmote STAR = new Emoji("⭐");
+            public static IEmote LVL_2_STAR = new Emoji("🌟");
+
+            public static IEmote LVL_3_STAR = new Emoji("💫");
         }
 
         public static DiscordSocketClient Bot { get; set;}

--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -101,7 +101,7 @@ namespace OnePlusBot.Base
             noticeEmbed.AddField("Unmuted User", OnePlusBot.Helpers.Extensions.FormatUserName(user))
                         .AddField("Mute Id", muteId)
                         .AddField("Muted since", $"{ muteObj.MuteDate:dd.MM.yyyy HH:mm}");
-            await guild.GetTextChannel(Global.Channels["modlog"]).SendMessageAsync(embed: noticeEmbed.Build());
+            await guild.GetTextChannel(Global.Channels["mutes"]).SendMessageAsync(embed: noticeEmbed.Build());
           }
         }
         db.SaveChanges();

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -203,12 +203,13 @@ namespace OnePlusBot.Base
             await base.Execute(message, channel, reaction);
             using (var db = new Database())
             {
-                var existing = db.StarboardPostRelations.Where(rel => rel.MessageId == message.Id && rel.UserId == message.Author.Id)
+                var existing = db.StarboardPostRelations.Where(rel => rel.MessageId == message.Id && rel.UserId == reaction.UserId)
                 .DefaultIfEmpty(null).First();
                 if(existing != null)
                 {
                     db.StarboardPostRelations.Remove(existing);
                 }
+                db.SaveChanges();
             }
          }
     }

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -38,7 +38,6 @@ namespace OnePlusBot.Base
             var starCount = await this.GetTrueStarCount(message, currentStarReaction);
             if(existingPostList.Any())
             {
-                this.RelationAdded = true;
                 var existingPost = existingPostList.First();
                 var starboardChannelPostId = existingPost.StarboardMessageId;
                 this.StarboardPostId = starboardChannelPostId;
@@ -46,17 +45,25 @@ namespace OnePlusBot.Base
                 using(var db = new Database())
                 {
                     var post = db.StarboardMessages.Where(p => p.MessageId == message.Id).First();
+                    if(post.Ignored)
+                    {
+                        return;
+                    }
                     post.Starcount = (uint) starCount;
                     db.SaveChanges();
                 }
+                this.RelationAdded = true;
                 var starboardChannelPost = await starboardChannel.GetMessageAsync(starboardChannelPostId) as IUserMessage;
-                if(starCount >= (int) Global.StarboardStars && starboardChannelPost != null )
+                if(starCount >= (int) Global.StarboardStars && starboardChannelPost != null)
                 {
                     await starboardChannelPost.ModifyAsync(msg => msg.Content = GetStarboardMessage(message, currentStarReaction, reaction, starCount));
                 } 
-                else if(starboardChannelPost != null)
+                else 
                 {
-                    await starboardChannelPost.DeleteAsync();
+                    if(starboardChannelPost != null) {
+                        await starboardChannelPost.DeleteAsync();
+                    }
+                    
                     Global.StarboardPosts.Remove(existingPost);
                     using(var db = new Database())
                     {
@@ -123,7 +130,16 @@ namespace OnePlusBot.Base
 
         private string GetStarboardMessage(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> reactionInfo, IReaction reaction, int starCount)
         {
-            return $"{reaction.Emote.Name} {starCount} <#{message.Channel.Id}> ID: {message.Id}"; 
+            var emote = Global.OnePlusEmote.STAR.Name;
+            if(starCount >= (int) Global.Level2Stars)
+            {
+                emote = Global.OnePlusEmote.LVL_2_STAR.Name;
+            }
+            if(starCount >= (int) Global.Level3Stars)
+            {
+                emote = Global.OnePlusEmote.LVL_3_STAR.Name;
+            }
+            return $"{emote} {starCount} <#{message.Channel.Id}> ID: {message.Id}"; 
         }
 
         private async Task<int> GetTrueStarCount(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> starReaction)

--- a/src/OnePlusBot/Data/Models/StarboardMessage.cs
+++ b/src/OnePlusBot/Data/Models/StarboardMessage.cs
@@ -19,6 +19,9 @@ namespace OnePlusBot.Data.Models
         [Column("author_id")]
         public ulong AuthorId { get; set; }
 
+        [Column("ignored")]
+        public bool Ignored { get; set; }
+
     }
 
 }

--- a/src/OnePlusBot/Data/Models/StarboardPostRelation.cs
+++ b/src/OnePlusBot/Data/Models/StarboardPostRelation.cs
@@ -12,5 +12,8 @@ namespace OnePlusBot.Data.Models
 
         [Column("message_id")]
         public ulong MessageId { get; set; }
+
+        [ForeignKey("MessageId")]
+        public virtual StarboardMessage Message { get; set; }
     }
 }


### PR DESCRIPTION
Moved unmutes to the proper channel
fixed handling of starboard messages. This includes marking them as ignored, and not including them in the star statistics. Does not work retroactively. 
Added configurable (db only) levels of stars, which causes the starboard posts to use different emotes for the message.
