### PR TITLE
Added scheduled warn decay

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -201,6 +201,8 @@ CREATE TABLE `Warnings` (
   `warned_by_id` bigint(20) unsigned NOT NULL,
   `reason` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `date` datetime NOT NULL,
+  `decayed` tinyint(4) NOT NULL,
+  `decayed_date` datetime DEFAULT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=11 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/sql_scripts/seed_data.sql
+++ b/sql_scripts/seed_data.sql
@@ -4,7 +4,8 @@ INSERT INTO `PersistentData` VALUES
 (3,'rolemanager_message_id',0),
 (4,'starboard_stars',1),
 (5,'level_2_stars',2),
-(6,'level_3_stars',3);
+(6,'level_3_stars',3),
+(7,'decay_days', 90);
 
 INSERT INTO `AuthTokens` VALUES 
 (1,'stable','REPLACE WITH TOKEN'),

--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -34,6 +34,7 @@ namespace OnePlusBot.Base
             {
                 await MuteTimerManager.SetupTimers(true);
                 await ReminderTimerManger.SetupTimers(true);
+                await WarningDecaytimerManager.SetupTimers();
             };
             if(Global.Token == string.Empty)
             {

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -33,6 +33,8 @@ namespace OnePlusBot.Base
         public static ulong Level2Stars { get; set; }
         public static ulong Level3Stars { get; set; }
 
+        public static ulong DecayDays { get; set; }
+
         public static List<StarboardMessage> StarboardPosts { get; set; }
         
         public static string Token
@@ -128,6 +130,10 @@ namespace OnePlusBot.Base
 
                 Level3Stars = db.PersistentData
                     .First(entry => entry.Name == "level_3_stars")
+                    .Value;
+                
+                DecayDays = db.PersistentData
+                    .First(entry => entry.Name == "decay_days")
                     .Value;
 
                 StarboardPosts.Clear();

--- a/src/OnePlusBot/Base/WarningDecayTimerManager.cs
+++ b/src/OnePlusBot/Base/WarningDecayTimerManager.cs
@@ -21,6 +21,7 @@ namespace OnePlusBot.Base
       TimeSpan thisMidnight = DateTime.Today.AddDays(1) - DateTime.Now;
       int secondsToDelay = (int) thisMidnight.TotalSeconds;
       await Task.Delay(secondsToDelay * 1000);
+      await DecayWarnings();
       System.Timers.Timer timer = new System.Timers.Timer(1000 * 60 * 60 * 24);
       timer.Elapsed += new System.Timers.ElapsedEventHandler(TriggerDecay);
       timer.Enabled = true;

--- a/src/OnePlusBot/Base/WarningDecayTimerManager.cs
+++ b/src/OnePlusBot/Base/WarningDecayTimerManager.cs
@@ -1,0 +1,90 @@
+using System.Text;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using Discord;
+using OnePlusBot.Data;
+using Discord.Commands;
+using System.Collections.ObjectModel;
+using OnePlusBot.Data.Models;
+using OnePlusBot.Helpers;
+
+using System.Collections.Generic;
+
+namespace OnePlusBot.Base
+{
+  public class WarningDecaytimerManager 
+  {
+      // TODO refactor this and MuteTimerManager to have a common abstract class or at least an interface
+    public static async Task<RuntimeResult> SetupTimers()
+    {
+      TimeSpan thisMidnight = DateTime.Today.AddDays(1) - DateTime.Now;
+      int secondsToDelay = (int) thisMidnight.TotalSeconds;
+      await Task.Delay(secondsToDelay * 1000);
+      System.Timers.Timer timer = new System.Timers.Timer(1000 * 60 * 60 * 24);
+      timer.Elapsed += new System.Timers.ElapsedEventHandler(TriggerDecay);
+      timer.Enabled = true;
+      return CustomResult.FromSuccess();
+    }
+
+    public static async void TriggerDecay(object sender, System.Timers.ElapsedEventArgs e)
+    {
+      System.Timers.Timer timer = (System.Timers.Timer)sender;
+      await DecayWarnings();
+    }        
+
+    public static async Task DecayWarnings()
+    {
+      var bot = Global.Bot;
+      var guild = bot.GetGuild(Global.ServerID);
+      var iGuildObj = (IGuild) guild;
+      var decayedWarnings = new Collection<WarnEntry>();
+      using (var db = new Database())
+      {
+        var now = DateTime.Now;
+        var maxDate = now.AddDays(-(double)Global.DecayDays);
+        var warningsToDecay = db.Warnings.Where(x => x.Date < maxDate && !x.Decayed).ToList();
+        if(warningsToDecay.Any())
+        {
+          foreach (var warning in warningsToDecay)
+          {
+            warning.Decayed = true;
+            warning.DecayedTime = now;
+            decayedWarnings.Add(warning);
+          }
+        }
+        db.SaveChanges();
+      }
+      await ReportDecay(decayedWarnings);
+    }
+
+    private static async Task ReportDecay(Collection<WarnEntry> warnings)
+    {
+      StringBuilder builder = new StringBuilder("");
+      var guild = Global.Bot.GetGuild(Global.ServerID);
+      foreach(var warning in warnings)
+      {
+        var user = guild.GetUser(warning.WarnedUserID);
+        var staff = guild.GetUser(warning.WarnedByID); 
+        builder.Append($"Warning towards {Extensions.FormatUserName(user)} on {warning.Date} with the reason '{warning.Reason}' by staff member {Extensions.FormatUserName(staff)}. \n \n");
+      }
+      if(builder.ToString() == string.Empty)
+      {
+        builder.Append("No warnings to decay");
+      }
+                
+                
+      var embed = new EmbedBuilder
+      {
+          Color = Color.Blue,
+          Title = $"Warnings have been decayed",
+          Description = builder.ToString(),
+          Timestamp = DateTime.Now
+      };
+
+      await guild.GetTextChannel(Global.Channels["modlog"]).SendMessageAsync(embed: embed.Build());
+    }
+
+  
+  }
+}

--- a/src/OnePlusBot/Data/Models/WarnEntry.cs
+++ b/src/OnePlusBot/Data/Models/WarnEntry.cs
@@ -29,5 +29,11 @@ namespace OnePlusBot.Data.Models
         
         [Column("date")]
         public DateTime Date { get; set; }
+
+        [Column("decayed")]
+        public bool Decayed { get; set; }
+
+        [Column("decayed_date")]
+        public DateTime DecayedTime { get; set; }
     }
 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -368,11 +368,13 @@ namespace OnePlusBot.Modules
                 var warnedBy = Context.Guild.GetUser(warning.WarnedByID);
                 if (_user != null)
                 {
+                    var decayed = warning.Decayed ? "yes" : "no";
                     var warnedByUserSafe = Extensions.FormatMentionDetailed(warnedBy);
                     embed.AddField(new EmbedFieldBuilder()
                         .WithName("Warning #" + counter + " (" + warning.ID + ")")
                         .WithValue($"**Reason**: {warning.Reason}\n" +
                                    $"**Warned by**: {warnedByUserSafe}\n" + 
+                                   $"*Decayed*: {decayed} \n" +
                                    $"*{warning.Date.ToString("dd/M/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}*"));
                 }
                 else
@@ -422,10 +424,10 @@ namespace OnePlusBot.Modules
 
                 if (!requestee.Roles.Any(x => x.Name == "Staff"))
                 {
-                    individualWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id);
-                    int indTotal = individualWarnings.Count();
+                    individualWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id && !x.Decayed);
+                    var decayedWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id && x.Decayed);
 
-                    await ReplyAsync($"You have {indTotal} active warnings.");
+                    await ReplyAsync($"You have {individualWarnings.Count()} active and {decayedWarnings.Count()} decayed warnings.");
 
                     return;
                 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -366,16 +366,18 @@ namespace OnePlusBot.Modules
             {
                 ++counter;
                 var warnedBy = Context.Guild.GetUser(warning.WarnedByID);
+
+                var decayed = warning.Decayed ? "" : "**Active**";
                 if (_user != null)
                 {
-                    var decayed = warning.Decayed ? "yes" : "no";
                     var warnedByUserSafe = Extensions.FormatMentionDetailed(warnedBy);
                     embed.AddField(new EmbedFieldBuilder()
                         .WithName("Warning #" + counter + " (" + warning.ID + ")")
                         .WithValue($"**Reason**: {warning.Reason}\n" +
                                    $"**Warned by**: {warnedByUserSafe}\n" + 
-                                   $"*Decayed*: {decayed} \n" +
-                                   $"*{warning.Date.ToString("dd/M/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}*"));
+                                   $"*{warning.Date.ToString("dd/M/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}* \n" +
+                                   $"{decayed} \n"
+                                   ));
                 }
                 else
                 {
@@ -385,8 +387,10 @@ namespace OnePlusBot.Modules
                     embed.AddField(new EmbedFieldBuilder()
                         .WithName($"Case #{warning.ID} - {warning.Date.ToString("dd/M/yyyy hh:mm:ss tt", CultureInfo.InvariantCulture)}")
                         .WithValue($"**Warned user**: {warnedSafe}\n" +
-                                   $"**Reason**: {warning.Reason}\n" +
-                                   $"**Warned by**: {warnedBySafe}"))
+                                   $"**Reason**: {warning.Reason} \n" +
+                                   $"**Warned by**: {warnedBySafe} \n" +
+                                   $"{decayed}"
+                                   ))
                         .WithFooter("*For more detailed info, consult the individual lists.*");
                 }
             }
@@ -424,10 +428,10 @@ namespace OnePlusBot.Modules
 
                 if (!requestee.Roles.Any(x => x.Name == "Staff"))
                 {
-                    individualWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id && !x.Decayed);
-                    var decayedWarnings = warnings.Where(x => x.WarnedUserID == requestee.Id && x.Decayed);
+                    individualWarnings = db.Warnings.Where(x => x.WarnedUserID == requestee.Id && !x.Decayed);
+                    var totalWarnings = db.Warnings.Where(x => x.WarnedUserID == requestee.Id);
 
-                    await ReplyAsync($"You have {individualWarnings.Count()} active and {decayedWarnings.Count()} decayed warnings.");
+                    await ReplyAsync($"You have {individualWarnings.Count()} active and {totalWarnings.Count()} total warnings.");
 
                     return;
                 }


### PR DESCRIPTION
This will create a scheduled job, which will run once per day at midnight.
At midnight, it will check if there exist warnings which are not yet decayed and older than a configurable amount of days. This value is currently only configurable in the DB, but a future improvement will create the possibility to set this value as well. 
If it finds anything, it will decay them and post a message to `modlog` containing the warnings which were decayed. In case no warning is decayed, a message will be posted as well indicating so.