### PR TITLE
Fixing incorrect way of using the Ready event

### DIFF
--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -29,13 +29,34 @@ namespace OnePlusBot.Base
             bot.Log += Log;
             bot.ReactionAdded += OnReactionAdded;
             bot.ReactionRemoved += OnReactionRemoved;
-
-            bot.Ready += async () => 
+            Func<Task> muteTimer = null;
+            muteTimer = () => 
             {
-                await MuteTimerManager.SetupTimers(true);
-                await ReminderTimerManger.SetupTimers(true);
-                await WarningDecaytimerManager.SetupTimers();
+                new MuteTimerManager().SetupTimers().ContinueWith(t => Console.WriteLine(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+                bot.Ready -= muteTimer;
+                return Task.CompletedTask;
             };
+            Func<Task> remindTimer = null;
+            remindTimer =  () => 
+            {
+                new ReminderTimerManger().SetupTimers().ContinueWith(t => Console.WriteLine(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+                bot.Ready -= remindTimer;
+                return Task.CompletedTask;
+            };
+
+            Func<Task> warnDecayTimer = null;
+            warnDecayTimer =  () => 
+            {
+                new WarningDecaytimerManager().SetupTimers().ContinueWith(t => Console.WriteLine(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+                bot.Ready -= warnDecayTimer;
+                return Task.CompletedTask;
+            };
+
+            bot.Ready += remindTimer;
+            bot.Ready += muteTimer;
+            bot.Ready += warnDecayTimer;
+           
+
             if(Global.Token == string.Empty)
             {
                 Console.WriteLine("Configure the token for the version you are trying to run in order to execute the bot");

--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -12,8 +12,23 @@ namespace OnePlusBot.Base
 {
   public class MuteTimerManager 
   {
-    public static async Task<RuntimeResult> SetupTimers(Boolean startup)
+    public async Task<RuntimeResult> SetupTimers()
     {
+      await Extensions.DelayUntilNextFullHour();
+      await ExecuteMuteLogic();
+      System.Timers.Timer timer1 = new System.Timers.Timer(1000 * 60 * 60);
+      timer1.Elapsed += new System.Timers.ElapsedEventHandler(TriggerTimer);
+      timer1.Enabled = true;
+      return CustomResult.FromSuccess();
+    }
+
+    public async void TriggerTimer(object sender, System.Timers.ElapsedEventArgs e)
+    {
+      System.Timers.Timer timer = (System.Timers.Timer)sender;
+      await ExecuteMuteLogic();
+    }        
+
+    public async Task ExecuteMuteLogic(){
       var bot = Global.Bot;
       var guild = bot.GetGuild(Global.ServerID);
       var iGuildObj = (IGuild) guild;
@@ -44,20 +59,7 @@ namespace OnePlusBot.Base
         }    
         db.SaveChanges();
       }
-      if(startup)
-      {
-        System.Timers.Timer timer1 = new System.Timers.Timer(1000 * 60 * 60);
-        timer1.Elapsed += new System.Timers.ElapsedEventHandler(TriggerTimer);
-        timer1.Enabled = true;
-      }
-      return CustomResult.FromSuccess();
     }
-
-    public static async void TriggerTimer(object sender, System.Timers.ElapsedEventArgs e)
-    {
-      System.Timers.Timer timer = (System.Timers.Timer)sender;
-      await SetupTimers(false);
-    }        
 
     public static async void UnmuteUserIn(ulong userId, TimeSpan time, ulong muteId)
     {

--- a/src/OnePlusBot/Base/ReminderTimerManager.cs
+++ b/src/OnePlusBot/Base/ReminderTimerManager.cs
@@ -14,9 +14,25 @@ namespace OnePlusBot.Base
   public class ReminderTimerManger 
   {
       // TODO refactor this and MuteTimerManager to have a common abstract class or at least an interface
-    public static async Task<RuntimeResult> SetupTimers(Boolean startup)
+    public async Task<RuntimeResult> SetupTimers()
     {
-      var bot = Global.Bot;
+      await Extensions.DelayUntilNextFullHour();
+      await ExecuteReminderLogic();
+      System.Timers.Timer timer1 = new System.Timers.Timer(1000 * 60 * 60);
+      timer1.Elapsed += new System.Timers.ElapsedEventHandler(TriggerTimer);
+      timer1.Enabled = true;
+      return CustomResult.FromSuccess();
+    }
+
+    public async void TriggerTimer(object sender, System.Timers.ElapsedEventArgs e)
+    {
+      System.Timers.Timer timer = (System.Timers.Timer)sender;
+      await ExecuteReminderLogic();
+    }
+
+    public async Task ExecuteReminderLogic()
+    {
+       var bot = Global.Bot;
       var guild = bot.GetGuild(Global.ServerID);
       var iGuildObj = (IGuild) guild;
       using (var db = new Database())
@@ -46,20 +62,7 @@ namespace OnePlusBot.Base
         }    
         db.SaveChanges();
       }
-      if(startup)
-      {
-        System.Timers.Timer timer1 = new System.Timers.Timer(1000 * 60 * 60);
-        timer1.Elapsed += new System.Timers.ElapsedEventHandler(TriggerTimer);
-        timer1.Enabled = true;
-      }
-      return CustomResult.FromSuccess();
     }
-
-    public static async void TriggerTimer(object sender, System.Timers.ElapsedEventArgs e)
-    {
-      System.Timers.Timer timer = (System.Timers.Timer)sender;
-      await SetupTimers(false);
-    }        
 
     public static async void RemindUserIn(ulong userId, TimeSpan time, ulong reminderId)
     {

--- a/src/OnePlusBot/Base/WarningDecayTimerManager.cs
+++ b/src/OnePlusBot/Base/WarningDecayTimerManager.cs
@@ -16,7 +16,7 @@ namespace OnePlusBot.Base
   public class WarningDecaytimerManager 
   {
       // TODO refactor this and MuteTimerManager to have a common abstract class or at least an interface
-    public static async Task<RuntimeResult> SetupTimers()
+    public async Task<RuntimeResult> SetupTimers()
     {
       TimeSpan thisMidnight = DateTime.Today.AddDays(1) - DateTime.Now;
       int secondsToDelay = (int) thisMidnight.TotalSeconds;
@@ -28,13 +28,13 @@ namespace OnePlusBot.Base
       return CustomResult.FromSuccess();
     }
 
-    public static async void TriggerDecay(object sender, System.Timers.ElapsedEventArgs e)
+    public async void TriggerDecay(object sender, System.Timers.ElapsedEventArgs e)
     {
       System.Timers.Timer timer = (System.Timers.Timer)sender;
       await DecayWarnings();
     }        
 
-    public static async Task DecayWarnings()
+    public async Task DecayWarnings()
     {
       var bot = Global.Bot;
       var guild = bot.GetGuild(Global.ServerID);
@@ -59,7 +59,7 @@ namespace OnePlusBot.Base
       await ReportDecay(decayedWarnings);
     }
 
-    private static async Task ReportDecay(Collection<WarnEntry> warnings)
+    private async Task ReportDecay(Collection<WarnEntry> warnings)
     {
       StringBuilder builder = new StringBuilder("");
       var guild = Global.Bot.GetGuild(Global.ServerID);
@@ -69,7 +69,7 @@ namespace OnePlusBot.Base
         var user = guild.GetUser(warning.WarnedUserID);
         var staff = guild.GetUser(warning.WarnedByID);
         var beforeAppending = builder.ToString();
-        var warnText = $"Warning towards {Extensions.FormatUserName(user)} on {warning.Date} with the reason '{warning.Reason}' by staff member {Extensions.FormatUserName(staff)}. \n \n";
+        var warnText = $"Warning towards {Extensions.FormatUserNameDetailed(user)} on {warning.Date} with the reason '{warning.Reason}' by staff member {Extensions.FormatUserNameDetailed(staff)}. \n \n";
         builder.Append(warnText);
         if(builder.ToString().Length > EmbedBuilder.MaxDescriptionLength)
         {

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -205,5 +205,14 @@ namespace OnePlusBot.Helpers
             }
             return builder.ToString();
         }
+
+        public static async Task DelayUntilNextFullHour()
+        {
+            TimeSpan sinceMidnight = DateTime.Now.TimeOfDay;
+            TimeSpan nextHour = TimeSpan.FromHours(Math.Ceiling(sinceMidnight.TotalHours));
+            TimeSpan timeSpanToDelay = (nextHour - sinceMidnight);
+            int secondsToDelay = (int) timeSpanToDelay.TotalSeconds;
+            await Task.Delay(secondsToDelay * 1000);
+        }
     }
 }


### PR DESCRIPTION
All timers for mutes/reminders/warndecays were initialized upon the Ready event on the bot. This was without the knowledge, that this event is also fired upon midnight.
This resulted in reminders triggering multiple times/warn decays as well.

This PR should fix this behavior. Before the fix I reproduced the issue locally and could see the same behavior once the day rolled over. 
It also brings some improvements in the structure of the remind and mute timer and causes these timers to run on each full hour instead of just an hour after the bot was started.