### PR TITLE
Fixes not showing all of the server emotes

### DIFF
--- a/src/OnePlusBot/Base/WarningDecayTimerManager.cs
+++ b/src/OnePlusBot/Base/WarningDecayTimerManager.cs
@@ -68,13 +68,15 @@ namespace OnePlusBot.Base
       {
         var user = guild.GetUser(warning.WarnedUserID);
         var staff = guild.GetUser(warning.WarnedByID);
-        var beforeAppending = builder.ToString();
-        var warnText = $"Warning towards {Extensions.FormatUserName(user)} on {warning.Date} with the reason '{warning.Reason}' by staff member {Extensions.FormatUserName(staff)}. \n \n";
-        builder.Append(warnText);
-        if(builder.ToString().Length > EmbedBuilder.MaxDescriptionLength)
+        var warnText = $"Warning towards {Extensions.FormatUserNameDetailed(user)} on {warning.Date} with the reason '{warning.Reason}' by staff member {Extensions.FormatUserName(staff)}. \n \n";
+        if((builder.ToString() + warnText).Length > EmbedBuilder.MaxDescriptionLength)
         {
-          texts.Add(beforeAppending);
+          texts.Add(builder.ToString());
           builder = new StringBuilder();
+          builder.Append(warnText);
+        }
+        else
+        {
           builder.Append(warnText);
         }
       }

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
@@ -12,6 +13,7 @@ using System;
 using Discord.WebSocket;
 using System.Net;
 using System.IO;
+using System.Collections.ObjectModel;
 
 namespace OnePlusBot.Modules
 {
@@ -310,11 +312,36 @@ namespace OnePlusBot.Modules
                 embed.WithThumbnailUrl(guild.IconUrl);
             if (guild.Emotes.Any())
             {
-                embed.AddField(fb =>
-                    fb.WithName("Custom emojis" + $"({guild.Emotes.Count})")
-                    .WithValue(string.Join(" ", guild.Emotes
-                        .Take(20)
-                        .Select(e => $"{e.ToString()}"))));
+                 
+                var strings = new Collection<StringBuilder>();
+                var currentStringBuilder = new StringBuilder();
+                strings.Add(currentStringBuilder);
+                foreach(var emote in guild.Emotes)
+                {
+                    var emoteText = emote.ToString();
+                    // doesnt seem to have a constant for that, exception message indicated the max length is 1024
+                    if((currentStringBuilder.ToString() + emoteText).Length > 1024)
+                    {
+                        currentStringBuilder = new StringBuilder();
+                        currentStringBuilder.Append(emoteText);
+                        strings.Add(currentStringBuilder);
+                    }
+                    else 
+                    {
+                        currentStringBuilder.Append(emoteText);
+                    }
+                }
+                var counter = 1;
+                foreach(var emoteText  in strings)
+                {
+                    var headerText = counter > 1 ? "#" + counter: "";
+                    var headerPostText = counter == 1 ? $"(Total: {guild.Emotes.Count})" : "";
+                    counter++;
+                    embed.AddField(fb =>
+                    fb.WithName($"Custom emojis {headerText} {headerPostText}")
+                    .WithValue(emoteText.ToString()));
+                }
+              
             }
             await Context.Channel.EmbedAsync(embed).ConfigureAwait(false);
         }


### PR DESCRIPTION
Before the amount of emotes shown in the serverinfo command was hard coded to 20.
With this change, this command takes all the emotes and splits them up into multiple fields in case it is too long. There is no handling in case the total embed length is too big, but the emotes are the only part which is very variable and could reach these amount, but for now we do not.

Also refactors how the message for the warn decay message is split up.