### PR TITLE
Show mute duration in unmute message

### DIFF
--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -100,6 +100,7 @@ namespace OnePlusBot.Base
 
             noticeEmbed.AddField("Unmuted User", OnePlusBot.Helpers.Extensions.FormatUserName(user))
                         .AddField("Mute Id", muteId)
+                        .AddField("Mute duration", Extensions.FormatTimeSpan(DateTime.Now - muteObj.MuteDate))
                         .AddField("Muted since", $"{ muteObj.MuteDate:dd.MM.yyyy HH:mm}");
             await guild.GetTextChannel(Global.Channels["mutes"]).SendMessageAsync(embed: noticeEmbed.Build());
           }

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -122,6 +122,7 @@ namespace OnePlusBot.Helpers
             CaptureCollection captures =  Regex.Match(duration, @"(\d+[a-z]+)+").Groups[1].Captures;
 
             DateTime targetTime = DateTime.Now;
+            DateTime timeAtStart = targetTime;
             // this basically means *one* of the values has been wrong, maybe negative or something like that
             bool validFormat = false;
             foreach(Capture capture in captures)
@@ -171,7 +172,7 @@ namespace OnePlusBot.Helpers
             {
                 throw new FormatException("Invalid format, it needs to be positive, and combinations of " + string.Join(", ", timeFormats));
             }
-            return targetTime - DateTime.Now;
+            return targetTime - timeAtStart;
         }
 
         public static string RemoveIllegalPings(string text){

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -112,7 +112,8 @@ namespace OnePlusBot.Modules
 
             string durationStr = arguments[0];
             TimeSpan span = Extensions.GetTimeSpanFromString(durationStr);
-            DateTime targetTime = DateTime.Now.Add(span);
+            var now = DateTime.Now;
+            DateTime targetTime = now.Add(span);
 
             string reason;
             if(arguments.Length > 1)
@@ -156,7 +157,7 @@ namespace OnePlusBot.Modules
 
             var muteData = new Mute
             {
-                MuteDate = DateTime.Now,
+                MuteDate = now,
                 UnmuteDate = targetTime,
                 MutedUser = user.Username + '#' + user.Discriminator,
                 MutedUserID = user.Id,


### PR DESCRIPTION
The unmute message now contains a field showing for how long the user has been muted.
This is the actual amount the user has been muted and not what the mute was configured in the database.

Also fixes a small second difference for the mute entry. Basically, the mute command does quite a few steps, and that causes the DateTime.now to have a different value later in the command than it did have in the beginning, causing this small second difference.