### PR TITLE
refactored invite link handling

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -224,4 +224,14 @@ CREATE TABLE `Reminders` (
  PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=23 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+
+DROP TABLE IF EXISTS `InviteLinks`;
+CREATE TABLE `InviteLinks` (
+ `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ `link` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+ `label` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
+ `added_date` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -26,6 +26,8 @@ namespace OnePlusBot.Base
         public static List<FAQCommandChannel> FAQCommandChannels { get; set;}
         public static List<FAQCommand> FAQCommands { get; set; }
 
+        public static List<InviteLink> InviteLinks { get; set; }
+
         public static ulong CommandExecutorId { get; set; }
 
         public static ulong StarboardStars { get; set; }
@@ -91,6 +93,7 @@ namespace OnePlusBot.Base
             ProfanityChecks = new List<Regex>();
             FAQCommands = new List<FAQCommand>();
             FAQCommandChannels = new List<FAQCommandChannel>();
+            InviteLinks = new List<InviteLink>();
             LoadGlobal();
         }
 
@@ -135,6 +138,12 @@ namespace OnePlusBot.Base
                 DecayDays = db.PersistentData
                     .First(entry => entry.Name == "decay_days")
                     .Value;
+
+                InviteLinks.Clear();
+                foreach(var link in db.InviteLinks)
+                {
+                    InviteLinks.Add(link);
+                }
 
                 StarboardPosts.Clear();
                 if(db.StarboardMessages.Any())

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -32,6 +32,8 @@ namespace OnePlusBot.Data
 
         public DbSet<StarboardPostRelation> StarboardPostRelations { get; set; }
 
+        public DbSet<InviteLink> InviteLinks { get; set; }
+
         // TODO needs to be replaced with proper dependency injection
         public static readonly LoggerFactory LoggerFactory
         = new LoggerFactory(new[] {new ConsoleLoggerProvider((_, __) => true, true)});

--- a/src/OnePlusBot/Data/Models/InviteLink.cs
+++ b/src/OnePlusBot/Data/Models/InviteLink.cs
@@ -1,0 +1,26 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("InviteLinks")]
+    public class InviteLink
+    {
+        [Key]
+        [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public uint ID { get; set; }
+
+        [Column("link")]
+        public string Link { get; set; }
+        
+        [Column("label")]
+        public string Label { get; set; }
+        
+        [Column("added_date")]
+        public DateTime AddedDate { get; set; }
+
+    }
+}


### PR DESCRIPTION
Moved the allowed invite links to the database and fixed a few bugs, which made it possible to post a invite link regardless of it being not allowed.
It is not possible to configure the links via a command, but only via the database.
The links in the database *need* to start with `discord.` and not with a `https` in order for it to work.