### PR TITLE
Various small fixes for modmail (ping roles)

### DIFF
--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -115,7 +115,7 @@ namespace OnePlusBot.Base
 
         private static void OnTimerElapsed(object sender, ElapsedEventArgs e)
         {
-            string[] status = { "Use ;help", "Made with the Fans™", "DM for Support" };
+            string[] status = { "Use ;help", "Made with the Fans™", "DM to contact mods" };
             Random ran = new Random();
             int index = ran.Next(status.Length);
 

--- a/src/OnePlusBot/Base/ModMailEmbedHandler.cs
+++ b/src/OnePlusBot/Base/ModMailEmbedHandler.cs
@@ -115,11 +115,12 @@ namespace OnePlusBot
             return builder.Build();
         }
 
-        public static Embed GetModqueueNotificationEmbed(SocketUser user){
+        public static Embed GetModqueueNotificationEmbed(SocketUser user, ModMailThread thread){
             var builder = GetBaseEmbed();
             builder.WithAuthor(GetUserAuthor(user));
             builder.WithTitle("A new modmail thread has been opened");
             builder.WithDescription($"The thread concerns {Extensions.FormatUserNameDetailed(user)}.");
+            builder.AddField("Link", Extensions.GetChannelUrl(Global.ServerID, thread.ChannelId, "Jump!"));
             return builder.Build();
         }
 


### PR DESCRIPTION
This PR fixes the critical issue of handling the staff role not properly. It is now being pinged properly.

Increased the delay between the messages being posted in modmaillog channel and added a link to the created channel in the modqueue notification. 

Adapted the streaming title to be a little bit more accurate.