### PR TITLE
muted modmail changes, another fix regarding duplicated reminders

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -91,6 +91,7 @@ CREATE TABLE `Mutes` (
   `reason` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `mute_date` datetime NOT NULL,
   `unmute_date` datetime NOT NULL,
+  `unmute_scheduled` tinyint(1) NOT NULL DEFAULT '0',
   `mute_ended` tinyint(1) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=82 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
@@ -200,6 +201,7 @@ CREATE TABLE `Reminders` (
  `reminded_user_id` bigint(20) unsigned NOT NULL,
  `remind_text` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
  `reminder_date` datetime NOT NULL,
+ `reminder_scheduled` tinyint(1) NOT NULL DEFAULT '0',
  `reminded` tinyint(1) NOT NULL DEFAULT '1',
  `channel_id` bigint(20) unsigned NOT NULL,
  `target_date` datetime NOT NULL,
@@ -276,6 +278,7 @@ CREATE TABLE `User` (
  `user_id` bigint(20) unsigned NOT NULL,
  `modmail_muted` tinyint(4) NOT NULL,
  `modmail_muted_until` datetime NOT NULL,
+ `modmail_muted_reminded` tinyint(4) NOT NULL,
  PRIMARY KEY (`user_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -536,7 +536,7 @@ namespace OnePlusBot.Base
         }
 
         private static bool ModMailThreadForUserExists(IUser user){
-                    return Global.ModMailThreads.Exists(ch => ch.UserId == user.Id && ch.State != "CLOSED");
+            return Global.ModMailThreads.Exists(ch => ch.UserId == user.Id && ch.State != "CLOSED");
         }
 
         private static bool ContainsIllegalInvite(string message)

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -102,6 +102,17 @@ namespace OnePlusBot.Base
             LoadGlobal();
         }
 
+        public static void ReloadModmailThreads(){
+            using (var db = new Database())
+            {
+                ModMailThreads.Clear();
+                ModMailThreads = db.ModMailThreads
+                    .Include(sub => sub.Subscriber)
+                    .Include(us => us.ThreadUser)
+                    .ToList();
+            }
+        }
+
         public static void LoadGlobal(){
             using (var db = new Database())
             {
@@ -154,10 +165,6 @@ namespace OnePlusBot.Base
                     .First(entry => entry.Name == "modmail_category_id")
                     .Value;
 
-                ModMailThreads.Clear();
-                ModMailThreads = db.ModMailThreads
-                    .Include(sub => sub.Subscriber)
-                    .ToList();
 
                 StarboardPosts.Clear();
                 if(db.StarboardMessages.Any())
@@ -191,6 +198,8 @@ namespace OnePlusBot.Base
                 FAQCommandChannels = ReadChannels;
                 FAQCommands = db.FAQCommands.ToList();
             }
+
+            ReloadModmailThreads();
         }
 
         public static class OnePlusEmote {

--- a/src/OnePlusBot/Data/Models/ModMailThread.cs
+++ b/src/OnePlusBot/Data/Models/ModMailThread.cs
@@ -27,6 +27,9 @@ namespace OnePlusBot.Data.Models
         [Column("state")]
         public string State { get; set; }
 
+        [ForeignKey("UserId")]
+        public virtual User ThreadUser { get; set; }
+
 
         public virtual ICollection<ThreadSubscriber> Subscriber { get; set; }
     }

--- a/src/OnePlusBot/Data/Models/Mute.cs
+++ b/src/OnePlusBot/Data/Models/Mute.cs
@@ -35,6 +35,9 @@ namespace OnePlusBot.Data.Models
         public DateTime UnmuteDate { get; set; }
 
         [Column("mute_ended")]
-        public Boolean MuteEnded {get; set;}
+        public Boolean MuteEnded { get; set; }
+
+        [Column("unmute_scheduled")]
+        public Boolean UnmuteScheduled { get; set; }
     }
 }

--- a/src/OnePlusBot/Data/Models/Reminder.cs
+++ b/src/OnePlusBot/Data/Models/Reminder.cs
@@ -26,7 +26,10 @@ namespace OnePlusBot.Data.Models
         public DateTime TargetDate { get; set; }
 
         [Column("reminded")]
-        public Boolean Reminded {get; set; }
+        public Boolean Reminded { get; set; }
+
+        [Column("reminder_scheduled")]
+        public Boolean ReminderScheduled { get; set; }
 
         [Column("channel_id")]
         public ulong ChannelId { get; set; }

--- a/src/OnePlusBot/Data/Models/User.cs
+++ b/src/OnePlusBot/Data/Models/User.cs
@@ -17,5 +17,8 @@ namespace OnePlusBot.Data.Models
 
         [Column("modmail_muted_until")]
         public DateTime ModMailMutedUntil { get; set; }
+
+        [Column("modmail_muted_reminded")]
+        public Boolean ModMailMutedReminded { get; set; }
     }
 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -197,6 +197,11 @@ namespace OnePlusBot.Modules
             {
                 var difference = targetTime - DateTime.Now;
                 MuteTimerManager.UnmuteUserIn(user.Id, difference, muteData.ID);
+                using (var db = new Database())
+                {
+                    db.Mutes.Where(m => m.ID == muteData.ID).First().UnmuteScheduled = true;
+                    db.SaveChanges();
+                }    
             }
            
             return CustomResult.FromSuccess();

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -347,13 +347,18 @@ namespace OnePlusBot.Modules
             {
                 db.Reminders.Add(reminder);
                 db.SaveChanges();
+                if(targetTime <= DateTime.Now.AddMinutes(60))
+                {
+                    var difference = targetTime - DateTime.Now;
+                    ReminderTimerManger.RemindUserIn(author.Id, difference, reminder.ID);
+                    reminder.ReminderScheduled = true;
+                }
+               
+                db.SaveChanges();
             }
 
-            if(targetTime <= DateTime.Now.AddMinutes(60))
-            {
-                var difference = targetTime - DateTime.Now;
-                ReminderTimerManger.RemindUserIn(author.Id, difference, reminder.ID);
-            }
+
+            
 
             return CustomResult.FromSuccess();
 


### PR DESCRIPTION
A user who is muted for modmail only gets a single notification regarding the time modmail is available again. This gets triggered after each time modmail gets disabled for a user individually.

Moved the muted state into the cache.

Fixed the cases in which both the TimerManagers and the '<60 minutes' trigger triggering events, causing for example for duplicate reminders. 