### PR TITLE
Changed the way banning is logged

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -39,7 +39,6 @@ namespace OnePlusBot.Base
             _bot.MessageReceived += OnMessageReceived;
             _bot.MessageDeleted += OnMessageRemoved;
             _bot.MessageUpdated += OnMessageUpdated;
-            _bot.UserBanned += OnUserBanned;
             _bot.UserUnbanned += OnUserUnbanned;
             _bot.UserVoiceStateUpdated += UserChangedVoiceState;
             _commands.CommandExecuted += OnCommandExecutedAsync;
@@ -93,36 +92,6 @@ namespace OnePlusBot.Base
                 .AddField(efb => efb
                     .WithName("By")
                     .WithValue(unbanLog.User)
-                    .WithIsInline(true)));
-        }
-
-        private async Task OnUserBanned(SocketUser socketUser, SocketGuild socketGuild)
-        {
-            var modlog = socketGuild.GetTextChannel(Global.Channels["banlog"]);
-
-            var restAuditLogs = await socketGuild.GetAuditLogsAsync(10).FlattenAsync();
-
-            var banLog = restAuditLogs.FirstOrDefault(x => x.Action == ActionType.Ban);
-
-
-            await modlog.EmbedAsync(new EmbedBuilder()
-                .WithColor(9896005)
-                .WithTitle("⛔️ Banned User")
-                .AddField(efb => efb
-                    .WithName("Username")
-                    .WithValue(socketUser.ToString())
-                    .WithIsInline(true))
-                .AddField(efb => efb
-                    .WithName("ID")
-                    .WithValue(socketUser.Id.ToString())
-                    .WithIsInline(true))
-                .AddField(efb => efb
-                    .WithName("Reason")
-                    .WithValue(banLog.Reason)
-                    .WithIsInline(true))
-                .AddField(efb => efb
-                    .WithName("By")
-                    .WithValue(banLog.User)
                     .WithIsInline(true)));
         }
 

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -43,10 +43,21 @@ namespace OnePlusBot.Modules
         public async Task<RuntimeResult> BanAsync(IGuildUser user, [Remainder] string reason = null)
         {
             if (user.IsBot)
+            {
                 return CustomResult.FromError("You can't ban bots.");
+            }
+
 
             if (user.GuildPermissions.PrioritySpeaker)
+            {
                 return CustomResult.FromError("You can't ban staff.");
+            }
+                
+            
+            if(reason == null)
+            {
+                reason = "No reason provided.";
+            }
             try
             {
                 try 
@@ -61,6 +72,27 @@ namespace OnePlusBot.Modules
                 await Context.Guild.AddBanAsync(user, 0, reason);
 
                 MuteTimerManager.UnMuteUserCompletely(user.Id);
+
+                var modlog = Context.Guild.GetTextChannel(Global.Channels["modlog"]);
+                var banlog = new EmbedBuilder()
+                .WithColor(9896005)
+                .WithTitle("⛔️ Banned User")
+                .AddField(efb => efb
+                    .WithName("User")
+                    .WithValue(Extensions.FormatUserNameDetailed(user))
+                    .WithIsInline(true))
+                .AddField(efb => efb
+                    .WithName("By")
+                    .WithValue(Extensions.FormatUserName(Context.User))
+                    .WithIsInline(true))
+                .AddField(efb => efb
+                    .WithName("Reason")
+                    .WithValue(reason))
+                .AddField(efb => efb
+                    .WithName("Link")
+                    .WithValue(Extensions.GetMessageUrl(Global.ServerID, Context.Channel.Id, Context.Message.Id, "Jump!")));
+
+                await modlog.SendMessageAsync(embed: banlog.Build());
 
                 return CustomResult.FromSuccess();
 


### PR DESCRIPTION
Removed the code for the even listener, and moved the logging to the actual execution of the command.
This means, that manual bans are not logged, because it would be duplicated, if we would also listen to the event.

Added link to the place where the ban was executed. This also means, that the true user executing the ban is shown instead of the bot.