### PR TITLE
added tracking of actual profanities

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -108,16 +108,48 @@ CREATE TABLE `PersistentData` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=7 DEFAULT CHARSET=latin1;
 
+
+--
+-- Table structure for table `User`
+--
+
+DROP TABLE IF EXISTS `User`;
+CREATE TABLE `User` (
+ `user_id` bigint(20) unsigned NOT NULL,
+ `modmail_muted` tinyint(4) NOT NULL,
+ `modmail_muted_until` datetime NOT NULL,
+ `modmail_muted_reminded` tinyint(4) NOT NULL,
+ PRIMARY KEY (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 --
 -- Table structure for table `ProfanityChecks`
 --
 
 DROP TABLE IF EXISTS `ProfanityChecks`;
 CREATE TABLE `ProfanityChecks` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `regex` text COLLATE utf8mb4_unicode_ci NOT NULL,
-  PRIMARY KEY (`id`)
+ `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ `regex` text COLLATE utf8mb4_unicode_ci NOT NULL,
+ `label` text COLLATE utf8mb4_unicode_ci NOT NULL,
+ PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=8 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+--
+-- Table structure for table `UsedProfanity`
+--
+
+DROP TABLE IF EXISTS `UsedProfanity`;
+CREATE TABLE `UsedProfanity` (
+ `user_id` bigint(20) unsigned NOT NULL,
+ `message_id` bigint(20) unsigned NOT NULL,
+ `profanity_id` int(10) unsigned NOT NULL,
+ `valid` tinyint(4) NOT NULL,
+ KEY `fk_user_id` (`user_id`),
+ KEY `fk_profanity_id` (`profanity_id`),
+ CONSTRAINT `fk_profanity_id` FOREIGN KEY (`profanity_id`) REFERENCES `ProfanityChecks` (`id`),
+ CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `User` (`user_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Table structure for table `ReferralCodes`
@@ -268,18 +300,5 @@ CREATE TABLE `ThreadMessage` (
  CONSTRAINT `fk_msg_id` FOREIGN KEY (`channel_id`) REFERENCES `ModMailThread` (`channel_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-
---
--- Table structure for table `User`
---
-
-DROP TABLE IF EXISTS `User`;
-CREATE TABLE `User` (
- `user_id` bigint(20) unsigned NOT NULL,
- `modmail_muted` tinyint(4) NOT NULL,
- `modmail_muted_until` datetime NOT NULL,
- `modmail_muted_reminded` tinyint(4) NOT NULL,
- PRIMARY KEY (`user_id`)
-) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -109,6 +109,7 @@ namespace OnePlusBot.Base
             RemoveReactionActions = new Collection<IReactionAction>();
             AddReactionActions.Add(new AddRoleReactionAction());
             AddReactionActions.Add(new StarboardAddedReactionAction());
+            AddReactionActions.Add(new ProfanityReportReactionAdded());
             RemoveReactionActions.Add(new RemoveRoleReactionAction());
             RemoveReactionActions.Add(new StarboardRemovedReactionAction());
         }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -147,11 +147,11 @@ namespace OnePlusBot.Base
                 if(!fullChannel.ProfanityCheckExempt){
                     var profanityChecks = Global.ProfanityChecks;
                     var lowerMessage = message.Content.ToLower();
-                    foreach (var regexObj in profanityChecks)
+                    foreach (var profanityCheck in profanityChecks)
                     {
-                        if(regexObj.Match(lowerMessage).Success)
+                        if(profanityCheck.RegexObj.Match(lowerMessage).Success)
                         {
-                            await ReportProfanity(message);
+                            await ReportProfanity(message, profanityCheck);
                             break;
                         }
                     }
@@ -510,7 +510,7 @@ namespace OnePlusBot.Base
             await message.DeleteAsync();
         }
 
-        private static async Task ReportProfanity(SocketMessage message){
+        private static async Task ReportProfanity(SocketMessage message, ProfanityCheck usedProfanity){
 
             var guild = Global.Bot.GetGuild(Global.ServerID);
             var builder = new EmbedBuilder();
@@ -521,18 +521,52 @@ namespace OnePlusBot.Base
             
             builder.ThumbnailUrl = message.Author.GetAvatarUrl();
 
-            const string discordUrl = "https://discordapp.com/channels/{0}/{1}/{2}";
             builder.AddField("User in question ", Extensions.FormatMentionDetailed(message.Author))
-                .AddField(
-                    "Location of the profane message",
-                    $"[#{message.Channel.Name}]({string.Format(discordUrl, guild.Id, message.Channel.Id, message.Id)})")
+                .AddField(f => {
+                    f.Name = "Location of the profane message";
+                    f.Value = Extensions.GetMessageUrl(Global.ServerID, message.Channel.Id, message.Id, message.Channel.Name);
+                    f.IsInline = true;
+                    })
+                .AddField(f => {
+                    f.Name ="Profanity type";
+                    f.Value = usedProfanity.Label;
+                    f.IsInline = true;
+                    })
                 .AddField("Message content", message.Content);
 
 
             var embed = builder.Build();
             var modQueue = guild.GetTextChannel(Global.Channels["modqueue"]);;
 
-            await modQueue.SendMessageAsync(null,embed: embed).ConfigureAwait(false);
+            var report = await modQueue.SendMessageAsync(null,embed: embed);
+
+            await report.AddReactionsAsync(new IEmote[]
+            {
+                Global.OnePlusEmote.OP_YES, 
+                Global.OnePlusEmote.OP_NO
+            });
+
+            var profanity = new UsedProfanity();
+            profanity.MessageId = report.Id;
+            profanity.UserId = message.Author.Id;
+            profanity.Valid = false;
+            profanity.ProfanityId = usedProfanity.ID;
+            using(var db = new Database()){
+                var user = db.Users.Where(us => us.UserId == message.Author.Id).FirstOrDefault();
+                if(user == null)
+                {
+                    var newUser = new User();
+                    newUser.UserId = message.Author.Id;
+                    newUser.ModMailMuted = false;
+                    db.Users.Add(newUser);
+                }
+               
+                db.Profanities.Add(profanity);
+                db.SaveChanges();
+            }
+
+            Global.ReportedProfanities.Add(profanity);
+           
         }
 
         private static bool ModMailThreadForUserExists(IUser user){
@@ -575,11 +609,11 @@ namespace OnePlusBot.Base
                 if(!channel.ProfanityCheckExempt){
                     var profanityChecks = Global.ProfanityChecks;
                     var lowerMessage = message.Content.ToLower();
-                    foreach (var regexObj in profanityChecks)
+                    foreach (var profanityCheck in profanityChecks)
                     {
-                        if(regexObj.Match(lowerMessage).Success)
+                        if(profanityCheck.RegexObj.Match(lowerMessage).Success)
                         {
-                            await ReportProfanity(message);
+                            await ReportProfanity(message, profanityCheck);
                             break;
                         }
                     }

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -84,7 +84,9 @@ namespace OnePlusBot.Base
             }
         }
 
-       public static List<Regex> ProfanityChecks { get; }
+       public static List<ProfanityCheck> ProfanityChecks { get; }
+
+       public static List<UsedProfanity> ReportedProfanities { get; }
 
         static Global()
         {
@@ -94,11 +96,12 @@ namespace OnePlusBot.Base
             NewsPosts = new Dictionary<ulong, ulong>();  
             StarboardPosts = new List<StarboardMessage>();  
             Roles = new Dictionary<string, ulong>();
-            ProfanityChecks = new List<Regex>();
+            ProfanityChecks = new List<ProfanityCheck>();
             FAQCommands = new List<FAQCommand>();
             FAQCommandChannels = new List<FAQCommandChannel>();
             InviteLinks = new List<InviteLink>();
             ModMailThreads = new List<ModMailThread>();
+            ReportedProfanities = new List<UsedProfanity>();
             LoadGlobal();
         }
 
@@ -180,7 +183,8 @@ namespace OnePlusBot.Base
                 {
                     foreach(var word in db.ProfanityChecks)
                     {
-                        ProfanityChecks.Add(new Regex(word.Word, RegexOptions.Singleline | RegexOptions.Compiled));
+                        word.RegexObj = new Regex(word.Word, RegexOptions.Singleline | RegexOptions.Compiled);
+                        ProfanityChecks.Add(word);
                     }
                 }
 
@@ -205,8 +209,8 @@ namespace OnePlusBot.Base
         public static class OnePlusEmote {
             public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
             public static IEmote FAIL = new Emoji("⚠");
-            public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
-            public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");
+            public static IEmote OP_YES =  Emote.Parse("<:OpYes:639787617604468736>");
+            public static IEmote OP_NO = Emote.Parse("<:OpNo:639787617860190208>");
 
             public static IEmote STAR = new Emoji("⭐");
             public static IEmote LVL_2_STAR = new Emoji("🌟");

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -209,8 +209,8 @@ namespace OnePlusBot.Base
         public static class OnePlusEmote {
             public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
             public static IEmote FAIL = new Emoji("⚠");
-            public static IEmote OP_YES =  Emote.Parse("<:OpYes:639787617604468736>");
-            public static IEmote OP_NO = Emote.Parse("<:OpNo:639787617860190208>");
+            public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
+            public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");
 
             public static IEmote STAR = new Emoji("⭐");
             public static IEmote LVL_2_STAR = new Emoji("🌟");

--- a/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
+++ b/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
@@ -1,0 +1,43 @@
+using System;
+using Discord;
+using Discord.Commands;
+using Discord.WebSocket;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using OnePlusBot.Data;
+
+namespace OnePlusBot.Base
+{
+    public class ProfanityReportReactionAdded : IReactionAction
+    {
+        public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            return Global.ReportedProfanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault() != null;
+        }
+        public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
+        {
+            using(var db = new Database())
+            {
+                var profanity = db.Profanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault();
+                if(profanity != null)
+                {
+                    if(reaction.Emote.Name == Global.OnePlusEmote.OP_NO.Name)
+                    {
+                        profanity.Valid = false;
+                    }
+                    else if(reaction.Emote.Name == Global.OnePlusEmote.OP_YES.Name)
+                    {
+                        profanity.Valid = true;
+                    }
+                    db.SaveChanges();
+                }
+            }
+            var prof = Global.ReportedProfanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault();
+            if(prof != null)
+            {
+                Global.ReportedProfanities.Remove(prof);
+            }
+        }
+    }
+}

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -35,6 +35,8 @@ namespace OnePlusBot.Data
 
         public DbSet<User> Users { get; set; }
 
+        public DbSet<UsedProfanity> Profanities { get; set; }
+
         public DbSet<ThreadMessage> ThreadMessages { get; set; }
         public DbSet<StarboardPostRelation> StarboardPostRelations { get; set; }
 

--- a/src/OnePlusBot/Data/Models/ProfanityCheck.cs
+++ b/src/OnePlusBot/Data/Models/ProfanityCheck.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
+using System.Text.RegularExpressions;
 
 namespace OnePlusBot.Data.Models
 {
@@ -13,5 +14,11 @@ namespace OnePlusBot.Data.Models
         
         [Column("regex")]
         public string Word { get; set; }
+
+        [Column("label")]
+        public string Label { get; set; }
+
+        [NotMapped]
+        public Regex RegexObj { get; set; }
     }
 }

--- a/src/OnePlusBot/Data/Models/UsedProfanity.cs
+++ b/src/OnePlusBot/Data/Models/UsedProfanity.cs
@@ -1,0 +1,30 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("UsedProfanity")]
+    public class UsedProfanity
+    {
+
+        [Column("user_id")]
+        public ulong UserId { get; set; }
+
+        [Column("message_id")]
+        [Key]
+        public ulong MessageId { get; set; }
+
+        [Column("profanity_id")]
+        public uint ProfanityId { get; set; }
+
+        [Column("valid")]
+        public bool Valid { get; set; }
+
+        [ForeignKey("UserId")]
+        public virtual User ProfanityUser { get; set; }
+
+        [ForeignKey("ProfanityId")]
+        public virtual ProfanityCheck TriggeredProfanity { get; set; }
+    }
+}

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -529,5 +529,35 @@ namespace OnePlusBot.Modules
             }
            
         }
+
+        [
+            Command("profanities"),
+            Summary("Shows the actual and false profanities of a user"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> ShowProfanities(IGuildUser user)
+        {
+            using(var db = new Database()){
+                var allProfanities = db.Profanities.Where(pro => pro.UserId == user.Id);
+                var actualProfanities = allProfanities.Where(pro => pro.Valid == true).Count();
+                var falseProfanities = allProfanities.Where(pro =>pro.Valid == false).Count();
+                var builder = new EmbedBuilder();
+                builder.AddField(f => {
+                    f.Name = "Actual";
+                    f.Value = actualProfanities;
+                    f.IsInline = true;
+                });
+
+                 builder.AddField(f => {
+                    f.Name = "False positives";
+                    f.Value = falseProfanities;
+                    f.IsInline = true;
+                });
+
+                builder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(user.GetAvatarUrl()).WithName(Extensions.FormatUserName(user)));
+                await Context.Channel.SendMessageAsync(embed: builder.Build());
+                return CustomResult.FromSuccess();
+            }
+        }
     }
 }


### PR DESCRIPTION
Effectively this means, when a profanity is being posted to modqueue. There are two reactions placed on the report.
The first staff member to react to either one of these decides what the result is: true positive or false positive. By default a posted profanity is a false positive. A reaction to the true side, makes it a true positive.

This PR also adds the notion of 'profanity labels', which is used as an additional sign what kind of profanity was used and is just used for reporting.

Also adds the (staff exclusive) command to see the profanity statistics for a given user.