### PR TITLE
Adds an attribute to a channel to make the channel invite check exempt

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -23,6 +23,7 @@ CREATE TABLE `Channels` (
   `channel_id` bigint(20) unsigned NOT NULL,
   `channel_type` int(11) NOT NULL,
   `profanity_check_exempt` tinyint(4) NOT NULL,
+  `invite_check_exempt` tinyint(4) NOT NULL,
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=52 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -577,7 +577,9 @@ namespace OnePlusBot.Base
         private static bool ViolatesRule(SocketMessage message)
         {
             string messageText = message.Content;
-            return ContainsIllegalInvite(messageText) && message.Channel.Id != Global.Channels["referralcodes"];
+            var channelObj = Global.FullChannels.Where(ch => ch.ChannelID == message.Channel.Id).FirstOrDefault();
+            bool ignoredChannel = channelObj != null && channelObj.InviteCheckExempt;
+            return ContainsIllegalInvite(messageText) && message.Channel.Id != Global.Channels["referralcodes"] && !ignoredChannel;
         }
 
         private static async Task OnMessageReceived(SocketMessage message)

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -27,6 +27,9 @@ namespace OnePlusBot.Data.Models
         [Column("profanity_check_exempt")]
         public bool ProfanityCheckExempt{ get; set;}
 
+        [Column("invite_check_exempt")]
+        public bool InviteCheckExempt{ get; set;}
+
         public virtual ICollection<FAQCommandChannel> CommandChannels { get; set; }
 
     }

--- a/src/OnePlusBot/Modules/Owner.cs
+++ b/src/OnePlusBot/Modules/Owner.cs
@@ -132,7 +132,8 @@ namespace OnePlusBot.Modules
                         Name = newName,
                         ChannelID = channel.Id,
                         ChannelType = ChannelType.Text,
-                        ProfanityCheckExempt = false
+                        ProfanityCheckExempt = false,
+                        InviteCheckExempt = false
                     });
 
                     Console.WriteLine($"[DB] [Update] Added channel {channel.Name} with Name {newName} and ID {channel.Id}");


### PR DESCRIPTION
This allows so invite links can be posted in certain (configured in the db) channels. Setup in the DB is already done.