### PR TITLE
Support for level 4 starboard tier

### DIFF
--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -36,6 +36,7 @@ namespace OnePlusBot.Base
 
         public static ulong Level2Stars { get; set; }
         public static ulong Level3Stars { get; set; }
+        public static ulong Level4Stars { get; set; }
 
         public static ulong ModmailCategoryId { get; set; }
 
@@ -155,6 +156,10 @@ namespace OnePlusBot.Base
                 Level3Stars = db.PersistentData
                     .First(entry => entry.Name == "level_3_stars")
                     .Value;
+
+                Level4Stars = db.PersistentData
+                    .First(entry => entry.Name == "level_4_stars")
+                    .Value;
                 
                 DecayDays = db.PersistentData
                     .First(entry => entry.Name == "decay_days")
@@ -222,6 +227,8 @@ namespace OnePlusBot.Base
             public static IEmote LVL_2_STAR = new Emoji("🌟");
 
             public static IEmote LVL_3_STAR = new Emoji("💫");
+
+            public static Emote LVL_4_STAR = Emote.Parse("<a:star4:640631410054529055>");
         }
 
         public static DiscordSocketClient Bot { get; set;}

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -139,6 +139,10 @@ namespace OnePlusBot.Base
             {
                 emote = Global.OnePlusEmote.LVL_3_STAR.Name;
             }
+            if(starCount >= (int) Global.Level4Stars)
+            {
+                emote = Global.OnePlusEmote.LVL_4_STAR.ToString();
+            }
             return $"{emote} {starCount} <#{message.Channel.Id}> ID: {message.Id}"; 
         }
 


### PR DESCRIPTION
Adds a new level used for the emote in starboard. The level is to be configured for 17 stars in the db.