### PR TITLE
Added xp tracking/channel groups and post targets (and small fixes)

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -123,6 +123,7 @@ CREATE TABLE `User` (
  `xp_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `current_role_id` int(10) unsigned DEFAULT NULL,
  `message_count` bigint(20) unsigned NOT NULL DEFAULT '0',
+ `xp_gain_disabled` tinyint(4) NOT NULL DEFAULT '0',
  PRIMARY KEY (`id`),
  KEY `fk_role_ref` (`current_role_id`),
  CONSTRAINT `fk_role_ref` FOREIGN KEY (`current_role_id`) REFERENCES `ExperienceRoles` (`id`)

--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -115,10 +115,17 @@ CREATE TABLE `PersistentData` (
 DROP TABLE IF EXISTS `User`;
 CREATE TABLE `User` (
  `id` bigint(20) unsigned NOT NULL,
- `modmail_muted` tinyint(4) NOT NULL,
- `modmail_muted_until` datetime NOT NULL,
- `modmail_muted_reminded` tinyint(4) NOT NULL,
- PRIMARY KEY (`user_id`)
+ `modmail_muted` tinyint(4) NOT NULL DEFAULT '0',
+ `modmail_muted_until` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ `modmail_muted_reminded` tinyint(4) NOT NULL DEFAULT '0',
+ `current_level` int(10) unsigned NOT NULL DEFAULT '0',
+ `xp` bigint(20) unsigned NOT NULL DEFAULT '0',
+ `xp_updated` datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ `current_role_id` int(10) unsigned DEFAULT NULL,
+ `message_count` bigint(20) unsigned NOT NULL DEFAULT '0',
+ PRIMARY KEY (`id`),
+ KEY `fk_role_ref` (`current_role_id`),
+ CONSTRAINT `fk_role_ref` FOREIGN KEY (`current_role_id`) REFERENCES `ExperienceRoles` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
@@ -147,7 +154,7 @@ CREATE TABLE `UsedProfanity` (
  KEY `fk_user_id` (`user_id`),
  KEY `fk_profanity_id` (`profanity_id`),
  CONSTRAINT `fk_profanity_id` FOREIGN KEY (`profanity_id`) REFERENCES `ProfanityChecks` (`id`),
- CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `User` (`user_id`)
+ CONSTRAINT `fk_user_id` FOREIGN KEY (`user_id`) REFERENCES `User` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
@@ -170,11 +177,11 @@ CREATE TABLE `ReferralCodes` (
 
 DROP TABLE IF EXISTS `Roles`;
 CREATE TABLE `Roles` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
-  `name` text NOT NULL,
-  `role_id` bigint(20) unsigned NOT NULL,
-  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=15 DEFAULT CHARSET=latin1;
+ `name` text NOT NULL,
+ `role_id` bigint(20) unsigned NOT NULL,
+ `xp_role` tinyint(4) NOT NULL DEFAULT '0',
+ PRIMARY KEY (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=latin1;
 
 --
 -- Table structure for table `StarboardMessages`
@@ -267,7 +274,7 @@ CREATE TABLE `ModMailThread` (
  `state` varchar(25) COLLATE utf8mb4_unicode_ci NOT NULL DEFAULT 'INITIAL',
  PRIMARY KEY (`channel_id`),
  KEY `fk_user_id_ref` (`user_id`),
- CONSTRAINT `fk_user_id_ref` FOREIGN KEY (`user_id`) REFERENCES `User` (`user_id`)
+ CONSTRAINT `fk_user_id_ref` FOREIGN KEY (`user_id`) REFERENCES `User` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --

--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -18,13 +18,10 @@ CREATE TABLE `AuthTokens` (
 
 DROP TABLE IF EXISTS `Channels`;
 CREATE TABLE `Channels` (
-  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `name` mediumtext COLLATE utf8mb4_unicode_ci NOT NULL,
   `channel_id` bigint(20) unsigned NOT NULL,
   `channel_type` int(11) NOT NULL,
-  `profanity_check_exempt` tinyint(4) NOT NULL,
-  `invite_check_exempt` tinyint(4) NOT NULL,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`channel_id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=52 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 
@@ -70,11 +67,11 @@ DROP TABLE IF EXISTS `FaqCommandChannel`;
 CREATE TABLE `FaqCommandChannel` (
   `command_channel_id` int(10) unsigned NOT NULL AUTO_INCREMENT,
   `command_id` int(10) unsigned NOT NULL,
-  `channel_id` int(10) unsigned NOT NULL,
+  `channel_group_id` int(10) unsigned NOT NULL,
   PRIMARY KEY (`command_channel_id`),
-  KEY `fk_channel_id` (`channel_id`),
+  KEY `fk_channel_group_id` (`channel_group_id`),
   KEY `command_id` (`command_id`),
-  CONSTRAINT `fk_channel_id` FOREIGN KEY (`channel_id`) REFERENCES `Channels` (`id`),
+  CONSTRAINT `fk_channel_group_id` FOREIGN KEY (`channel_group_id`) REFERENCES `ChannelGroups` (`id`),
   CONSTRAINT `fk_command_id` FOREIGN KEY (`command_id`) REFERENCES `FaqCommand` (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=359 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
@@ -117,7 +114,7 @@ CREATE TABLE `PersistentData` (
 
 DROP TABLE IF EXISTS `User`;
 CREATE TABLE `User` (
- `user_id` bigint(20) unsigned NOT NULL,
+ `id` bigint(20) unsigned NOT NULL,
  `modmail_muted` tinyint(4) NOT NULL,
  `modmail_muted_until` datetime NOT NULL,
  `modmail_muted_reminded` tinyint(4) NOT NULL,
@@ -290,7 +287,6 @@ CREATE TABLE `ThreadSubscribers` (
 -- Table structure for table `ThreadMessage`
 --
 
-
 DROP TABLE IF EXISTS `ThreadMessage`;
 CREATE TABLE `ThreadMessage` (
  `channel_id` bigint(20) unsigned NOT NULL,
@@ -302,5 +298,41 @@ CREATE TABLE `ThreadMessage` (
  CONSTRAINT `fk_msg_id` FOREIGN KEY (`channel_id`) REFERENCES `ModMailThread` (`channel_id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+--
+-- Table structure for table `ChannelGroups`
+--
+
+CREATE TABLE `ChannelGroups` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `profanity_check_exempt` tinyint(4) NOT NULL,
+  `invite_check_exempt` tinyint(4) NOT NULL,
+  `exp_gain_exempt` tinyint(4) NOT NULL,
+  `disabled` tinyint(4) NOT NULL,
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=2 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `ChannelInGroup`
+--
+
+CREATE TABLE `ChannelInGroup` (
+ `channel_id` bigint(20) unsigned NOT NULL,
+ `channel_group_id` int(10) unsigned NOT NULL,
+ PRIMARY KEY (`channel_id`,`channel_group_id`),
+ KEY `fk_group_id` (`channel_group_id`),
+ CONSTRAINT `fk_group_id` FOREIGN KEY (`channel_group_id`) REFERENCES `ChannelGroups` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `PostTargets`
+--
+
+CREATE TABLE `PostTargets` (
+ `channel_id` bigint(20) unsigned NOT NULL,
+ `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+ PRIMARY KEY (`name`),
+ UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/sql_scripts/seed_data.sql
+++ b/sql_scripts/seed_data.sql
@@ -7,27 +7,19 @@ INSERT INTO `PersistentData` VALUES
 (6,'level_3_stars',3, ''),
 (7,'decay_days', 90, ''),
 (8, 'modmail_category_id', 0, ''),
-(9, 'user_name_illegal_characters', 0, '');
+(9, 'user_name_illegal_characters', 0, ''),
+(10, 'xp_disabled', 1, ''),
+(11, 'xp_gain_range_min', 10, ''),
+(12, 'xp_gain_range_max', 10, '');
 
 INSERT INTO `AuthTokens` VALUES 
 (1,'stable','REPLACE WITH TOKEN'),
 (2,'beta','REPLACE WITH TOKEN');
 
 
-INSERT INTO `Channels` (`id`, `name`, `channel_id`, `channel_type`, `profanity_check_exempt`) VALUES
-(8, 'setups', 0, 0, 0),
-(9, 'news', 0, 0, 1),
-(14, 'suggestions', 0, 0, 1),
-(18, 'modlog', 0, 0, 1),
-(20, 'referralcodes', 0, 0, 0),
-(23, 'joinlog', 0, 0, 1),
-(28, 'info', 0, 0, 1),
-(39, 'warnings', 0, 0, 1),
-(43, 'starboard', 0, 0, 1),
-(47, 'mutes', 0, 0, 1),
-(48, 'modqueue', 0, 0, 1),
-(49, 'modmaillog', 0, 0, 1),
-(50, 'banlog', 0, 0, 0);
+INSERT INTO `Channels` (`name`, `channel_id`, `channel_type`) VALUES
+('setups', 0, 0),
+('referralcodes', 0, 0);
 
-INSERT INTO  `Roles` (`id` ,`name`, `role_id` ) VALUES 
-(1, 'staff', 0);
+INSERT INTO  `Roles` (`name`, `role_id` ) VALUES
+('staff', 0);

--- a/sql_scripts/seed_data.sql
+++ b/sql_scripts/seed_data.sql
@@ -10,7 +10,7 @@ INSERT INTO `PersistentData` VALUES
 (9, 'user_name_illegal_characters', 0, ''),
 (10, 'xp_disabled', 1, ''),
 (11, 'xp_gain_range_min', 10, ''),
-(12, 'xp_gain_range_max', 10, '');
+(12, 'xp_gain_range_max', 25, '');
 
 INSERT INTO `AuthTokens` VALUES 
 (1,'stable','REPLACE WITH TOKEN'),

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -19,7 +19,7 @@ namespace OnePlusBot.Base
             using(var db = new Database()){
                 var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
                 if(existingGroup != null){
-                    throw new ChannelGroupException("Channel group with name already exists.");
+                    throw new NotFoundException("Channel group with name already exists.");
                 }
                 var channelGroup = new ChannelGroup();
                 channelGroup.Name = name;
@@ -49,7 +49,7 @@ namespace OnePlusBot.Base
                     }
                     db.SaveChanges();
                 } else {
-                    throw new ChannelGroupException("Channel group not found.");
+                    throw new NotFoundException("Channel group not found.");
                 }
                 
             }
@@ -72,7 +72,7 @@ namespace OnePlusBot.Base
                     }
                     db.SaveChanges();
                 } else {
-                    throw new ChannelGroupException("Channel group not found.");
+                    throw new NotFoundException("Channel group not found.");
                 }
                 
             }
@@ -86,7 +86,7 @@ namespace OnePlusBot.Base
                 {
                     existingGroup.ExperienceGainExempt = newVal;
                 } else {
-                    throw new ChannelGroupException("Channel group not found.");
+                    throw new NotFoundException("Channel group not found.");
                 }
                 db.SaveChanges();
             }
@@ -101,7 +101,7 @@ namespace OnePlusBot.Base
                 {
                     existingGroup.Disabled = newVal;
                 } else {
-                    throw new ChannelGroupException("Channel group not found.");
+                    throw new NotFoundException("Channel group not found.");
                 }
                 db.SaveChanges();
             }
@@ -208,7 +208,7 @@ namespace OnePlusBot.Base
                 }
                 else 
                 {
-                    throw new ChannelGroupException("Channel group not found.");
+                    throw new NotFoundException("Channel group not found.");
                 }
                 db.SaveChanges();
             }

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -100,7 +100,9 @@ namespace OnePlusBot.Base
                 if(existingGroup != null)
                 {
                     existingGroup.Disabled = newVal;
-                } else {
+                }
+                else 
+                {
                     throw new NotFoundException("Channel group not found.");
                 }
                 db.SaveChanges();
@@ -108,7 +110,40 @@ namespace OnePlusBot.Base
 
         }
 
-        public void setPostTarget(string name, IChannel channel)
+        public async Task PostExistingPostTargets(ISocketMessageChannel channelToRespondIn) 
+        {
+          var stringBuilder = new StringBuilder();
+          foreach(var target in PostTarget.POST_TARGETS){
+            stringBuilder.Append($"`{target}` ");
+          }
+          var builder = new EmbedBuilder();
+          builder.WithTitle("Currently available post targets");
+          builder.WithDescription(stringBuilder.ToString());
+          await channelToRespondIn.SendMessageAsync(embed: builder.Build());
+        }
+
+        public void RenameChannelGroup(string oldName, string newName) {
+          using(var db = new Database())
+          {
+            var existingGroup = db.ChannelGroups.Where(grp => grp.Name == oldName).FirstOrDefault();
+            if(existingGroup != null)
+            {
+              var newNameIsused = db.ChannelGroups.Where(grp => grp.Name == newName).Any();
+              if(newNameIsused)
+              {
+                throw new ConfigurationException("New name is already used by anothe group.");
+              }
+              existingGroup.Name = newName;
+            }
+            else 
+            {
+                throw new NotFoundException("Channel group not found.");
+            }
+            db.SaveChanges();
+          }
+        }
+
+        public void SetPostTarget(string name, IChannel channel)
         {
             using(var db = new Database())
             {

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -17,9 +17,11 @@ namespace OnePlusBot.Base
     {
         public void createChannelGroup(string name)
         {
-            using(var db = new Database()){
+            using(var db = new Database())
+            {
                 var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
-                if(existingGroup != null){
+                if(existingGroup != null)
+                {
                     throw new NotFoundException("Channel group with name already exists.");
                 }
                 var channelGroup = new ChannelGroup();
@@ -40,7 +42,8 @@ namespace OnePlusBot.Base
                     foreach(var channel in message.MentionedChannels)
                     {
                         var doesChannelGroupEntryAlreadyExist = db.ChannelGroupMembers.Where(mem => mem.ChannelGroupId == existingGroup.Id && mem.ChannelId == channel.Id).Count() != 0;
-                        if(!doesChannelGroupEntryAlreadyExist){
+                        if(!doesChannelGroupEntryAlreadyExist)
+                        {
                             var channelGroupMember = new ChannelInGroup();
                             channelGroupMember.ChannelGroupId = existingGroup.Id;
                             channelGroupMember.ChannelId = channel.Id;
@@ -49,7 +52,9 @@ namespace OnePlusBot.Base
                       
                     }
                     db.SaveChanges();
-                } else {
+                }
+                else 
+                {
                     throw new NotFoundException("Channel group not found.");
                 }
                 
@@ -72,14 +77,16 @@ namespace OnePlusBot.Base
                         }
                     }
                     db.SaveChanges();
-                } else {
+                }
+                else 
+                {
                     throw new NotFoundException("Channel group not found.");
                 }
-                
             }
         }
 
-        public void setExpDisabledTo(string name, bool newVal, Boolean? inviteCheck, Boolean? profanityCheck){
+        public void SetChannelGroupAttributes(string name, bool newVal, Boolean? inviteCheck, Boolean? profanityCheck)
+        {
             using(var db = new Database())
             {
                 var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
@@ -94,15 +101,17 @@ namespace OnePlusBot.Base
                     {
                       existingGroup.ProfanityCheckExempt = profanityCheck.GetValueOrDefault();
                     }
-                } else {
+                }
+                else 
+                {
                     throw new NotFoundException("Channel group not found.");
                 }
                 db.SaveChanges();
             }
-
         }
 
-        public void setGroupDisabledTo(string name, bool newVal){
+        public void setGroupDisabledTo(string name, bool newVal)
+        {
             using(var db = new Database())
             {
                 var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
@@ -122,7 +131,8 @@ namespace OnePlusBot.Base
         public async Task PostExistingPostTargets(ISocketMessageChannel channelToRespondIn) 
         {
           var stringBuilder = new StringBuilder();
-          foreach(var target in PostTarget.POST_TARGETS){
+          foreach(var target in PostTarget.POST_TARGETS)
+          {
             stringBuilder.Append($"`{target}` ");
           }
           var builder = new EmbedBuilder();
@@ -131,7 +141,8 @@ namespace OnePlusBot.Base
           await channelToRespondIn.SendMessageAsync(embed: builder.Build());
         }
 
-        public void RenameChannelGroup(string oldName, string newName) {
+        public void RenameChannelGroup(string oldName, string newName) 
+        {
           using(var db = new Database())
           {
             var existingGroup = db.ChannelGroups.Where(grp => grp.Name == oldName).FirstOrDefault();
@@ -170,12 +181,12 @@ namespace OnePlusBot.Base
                     newPostTarget.ChannelId = channel.Id;
                     db.PostTargets.Add(newPostTarget);
                 }
-              
                 db.SaveChanges();
             }
         }
 
-        public Collection<Embed> GetChannelListEmbed(){
+        public Collection<Embed> GetChannelListEmbed()
+        {
             Collection<Embed> embedsToPost = new Collection<Embed>();
             using(var db = new Database())
             {
@@ -188,13 +199,13 @@ namespace OnePlusBot.Base
                     count++;
                     var disabledIndicator = group.Disabled ? " (Disabled)" : "";
                     currentEmbedBuilder.AddField($"**{group.Name}**{disabledIndicator}, XP exempt: {group.ExperienceGainExempt}  Profanity check exempt: {group.ProfanityCheckExempt}, InviteCheck exempt: {group.InviteCheckExempt}", getChannelsAsMentions(group.Channels));
-                    if(((count % EmbedBuilder.MaxFieldCount) == 0) && group != channelGroups.Last()){
+                    if(((count % EmbedBuilder.MaxFieldCount) == 0) && group != channelGroups.Last())
+                    {
                         embedsToPost.Add(currentEmbedBuilder.Build());
                         currentEmbedBuilder = new EmbedBuilder();
                         var currentPage = count / EmbedBuilder.MaxFieldCount + 1;
                         currentEmbedBuilder.WithFooter(new EmbedFooterBuilder().WithText($"Page {currentPage}"));
-                    }
-                   
+                    }  
                 }
                 embedsToPost.Add(currentEmbedBuilder.Build());
             }
@@ -204,22 +215,26 @@ namespace OnePlusBot.Base
         public async Task ListChannelGroups(ISocketMessageChannel channelToRespondIn)
         {
             var embedsToPost = GetChannelListEmbed();
-            foreach(Embed embed in embedsToPost){
+            foreach(Embed embed in embedsToPost)
+            {
                 await channelToRespondIn.SendMessageAsync(embed: embed);
                 await Task.Delay(200);
             }
         }
 
-        private string getChannelsAsMentions(ICollection<ChannelInGroup> channels){
+        private string getChannelsAsMentions(ICollection<ChannelInGroup> channels)
+        {
             StringBuilder stringRepresentation = new StringBuilder();
-            foreach(ChannelInGroup ch in channels){
+            foreach(ChannelInGroup ch in channels)
+            {
                 stringRepresentation.Append($"<#{ch.ChannelId}> ");
             }
 
             return stringRepresentation.ToString() != string.Empty ? stringRepresentation.ToString() : "no channels.";
         }
 
-        public Dictionary<string, bool> EvaluateChannelConfiguration(IChannel channel){
+        public Dictionary<string, bool> EvaluateChannelConfiguration(IChannel channel)
+        {
             using(var db = new Database())
             {
                 var perms = db.ChannelGroupMembers.Include(ch => ch.Group).Include(ch => ch.ChannelReference).Where(ch => ch.ChannelId == channel.Id).ToList();
@@ -228,7 +243,8 @@ namespace OnePlusBot.Base
                 var xpDisabled = false;
                 foreach(var groupMember in perms)
                 {
-                    if(!groupMember.Group.Disabled){
+                    if(!groupMember.Group.Disabled)
+                    {
                         profanityDisabled |= groupMember.Group.ProfanityCheckExempt;
                         inviteLinksDisabled |= groupMember.Group.InviteCheckExempt;
                         xpDisabled |= groupMember.Group.ExperienceGainExempt;

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -1,0 +1,90 @@
+using System.Linq;
+using Discord.WebSocket;
+using OnePlusBot.Data;
+using OnePlusBot.Data.Models;
+
+namespace OnePlusBot.Base
+{
+    public class ChannelManager
+    {
+        public void createChannelGroup(string name)
+        {
+            using(var db = new Database()){
+                var channelGroup = new ChannelGroup();
+                channelGroup.Name = name;
+                db.ChannelGroups.Add(channelGroup);
+                
+                db.SaveChanges();
+            }
+        }
+
+        public void addChannelsToChannelGroup(string name, SocketMessage message)
+        {
+            using(var db = new Database())
+            {
+                var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
+                if(existingGroup != null)
+                {
+                    foreach(var channel in message.MentionedChannels)
+                    {
+                        var doesChannelGroupEntryAlreadyExist = db.ChannelGroupMembers.Where(mem => mem.ChannelGroupId == existingGroup.Id && mem.ChannelId == channel.Id).Count() != 0;
+                        if(!doesChannelGroupEntryAlreadyExist){
+                            var channelGroupMember = new ChannelInGroup();
+                            channelGroupMember.ChannelGroupId = existingGroup.Id;
+                            channelGroupMember.ChannelId = channel.Id;
+                            db.ChannelGroupMembers.Add(channelGroupMember);
+                        }
+                      
+                    }
+                    db.SaveChanges();
+                }
+                
+            }
+        }
+
+        public void removeChannelsFromGroup(string name, SocketMessage message)
+        {
+            using(var db = new Database())
+            {
+                var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
+                if(existingGroup != null)
+                {
+                    foreach(var channel in message.MentionedChannels)
+                    {
+                        var existingChannelEntry = db.ChannelGroupMembers.Where(mem => mem.ChannelGroupId == existingGroup.Id && mem.ChannelId == channel.Id).FirstOrDefault();
+                        if(existingChannelEntry != null)
+                        {
+                            db.ChannelGroupMembers.Remove(existingChannelEntry);
+                        }
+                    }
+                    db.SaveChanges();
+                }
+                
+            }
+        }
+
+        public void setPostTarget(string name, SocketUserMessage message)
+        {
+            ulong channelIdToSet = message.MentionedChannels.First().Id;
+            using(var db = new Database())
+            {
+                var existingTarget = db.PostTargets.Where(pt => pt.Name == name).FirstOrDefault();
+                PostTarget newPostTarget;
+                if(existingTarget != null)
+                {
+                    newPostTarget = existingTarget;
+                    newPostTarget.ChannelId = channelIdToSet;
+                }
+                else
+                {
+                    newPostTarget = new PostTarget();
+                    newPostTarget.Name = name;
+                    newPostTarget.ChannelId = channelIdToSet;
+                    db.PostTargets.Add(newPostTarget);
+                }
+              
+                db.SaveChanges();
+            }
+        }
+    }
+}

--- a/src/OnePlusBot/Base/ConfigurationStep.cs
+++ b/src/OnePlusBot/Base/ConfigurationStep.cs
@@ -1,8 +1,8 @@
+using System.Threading.Tasks;
 using System.Text;
 using System.Collections.ObjectModel;
 using System;
 using System.Linq;
-using System.Threading.Tasks;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
@@ -38,9 +38,9 @@ namespace OnePlusBot.Base {
         private ConfigurationStep parent;
         public Collection<string> additionalPosts = new Collection<string>();
 
-        public Func<String, ConfigurationStep, bool> TextCallback { get; set; }
+        public Func<String, ConfigurationStep, Task> TextCallback { get; set; }
 
-        public Func<ConfigurationStep, bool> beforeTextPosted { get; set; }
+        public Func<ConfigurationStep, Task> beforeTextPosted { get; set; }
 
 
         // the text to post to end the step
@@ -75,7 +75,7 @@ namespace OnePlusBot.Base {
             Interactive.ClearReactionCallbacks();
             if(this.beforeTextPosted != null)
             {
-                this.beforeTextPosted(this);
+                await this.beforeTextPosted(this);
             }
             if(additionalPosts.Count > 0)
             {
@@ -333,7 +333,7 @@ namespace OnePlusBot.Base {
             step.Actions.Add(forwardAction);
             step.Actions.Add(abortDeletionAction);
 
-            step.beforeTextPosted = (ConfigurationStep a) => 
+            step.beforeTextPosted = async (ConfigurationStep a) => 
             {
                 a.additionalPosts.Clear();
                 for(int i = currentPage * elementOnPage; i < currentPage * elementOnPage + elementOnPage && i < elements.Count; i++)
@@ -341,7 +341,7 @@ namespace OnePlusBot.Base {
                     var cmd = elements[i];
                     a.additionalPosts.Add(cmd.display());
                 }
-                return false;
+                await Task.CompletedTask;
             };
         }
 

--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -1,18 +1,14 @@
-﻿using System.Net;
-using System.Collections.ObjectModel;
-using System.Runtime.CompilerServices;
-using System.Data.Common;
+﻿using System.Collections.ObjectModel;
 using Discord;
 using Discord.Addons.Interactive;
 using Discord.Commands;
 using Discord.WebSocket;
 using Microsoft.Extensions.DependencyInjection;
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Net.Http;
 using System.Threading.Tasks;
 using System.Timers;
+using OnePlusBot.Data.Models;
 
 namespace OnePlusBot.Base
 {
@@ -52,9 +48,18 @@ namespace OnePlusBot.Base
                 return Task.CompletedTask;
             };
 
+            Func<Task> expPersister = null;
+            expPersister = () => 
+            {
+                new ExpManager().SetupTimers().ContinueWith(t => Console.WriteLine(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+                bot.Ready -= expPersister;
+                return Task.CompletedTask;
+            };
+
             bot.Ready += remindTimer;
             bot.Ready += muteTimer;
             bot.Ready += warnDecayTimer;
+            bot.Ready += expPersister;
            
 
             if(Global.Token == string.Empty)
@@ -98,7 +103,7 @@ namespace OnePlusBot.Base
         /*private static void T2_Elapsed(object sender, ElapsedEventArgs e)
         {
             var guild = Global.Bot.GetGuild(Global.ServerID);
-            var offtopic = guild.GetTextChannel(Global.Channels["offtopic"]);
+            var offtopic = guild.GetTextChannel(Global.PostTargets[PostTarget.OFFTOPIC]);
             var Faded = guild.GetUser(167897643131863040);
             offtopic.SendMessageAsync(Faded.Mention + " Ho Ho Ho! 🎅");
         }*/

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -391,13 +391,7 @@ namespace OnePlusBot.Base
                     if (result.ErrorReason == "Unknown command.")
                     return;
 
-                    await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);
-
-                    if (result.ErrorReason == "The input text has too few parameters.")
-                    {
-                        return;
-                    }
-                  
+                    await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);                 
 
                     await context.Channel.SendMessageAsync(result.ErrorReason);
                     return;
@@ -631,7 +625,8 @@ namespace OnePlusBot.Base
             
             var minute = (long) DateTime.Now.Subtract(DateTime.MinValue).TotalMinutes;
             var exists = Global.RuntimeExp.ContainsKey(minute);
-            if(!exists){
+            if(!exists)
+            {
                 var element = new List<ulong>();
                 element.Add(message.Author.Id);
                 Global.RuntimeExp.TryAdd(minute, element);
@@ -640,7 +635,8 @@ namespace OnePlusBot.Base
             {
                 List<ulong> poster = new List<ulong>();
                 Global.RuntimeExp.TryGetValue(minute, out poster);
-                if(!poster.Contains(message.Author.Id)){
+                if(!poster.Contains(message.Author.Id))
+                {
                     poster.Add(message.Author.Id);
                 }
             }
@@ -655,8 +651,10 @@ namespace OnePlusBot.Base
             }
 
             var channel = Extensions.GetChannelById(message.Channel.Id);
-            if(channel != null){
-                if(!channel.ProfanityExempt()){
+            if(channel != null)
+            {
+                if(!channel.ProfanityExempt())
+                {
                     var profanityChecks = Global.ProfanityChecks;
                     var lowerMessage = message.Content.ToLower();
                     foreach (var profanityCheck in profanityChecks)

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -634,11 +634,12 @@ namespace OnePlusBot.Base
             if(!exists){
                 var element = new List<ulong>();
                 element.Add(message.Author.Id);
-                Global.RuntimeExp.Add(minute, element);
+                Global.RuntimeExp.TryAdd(minute, element);
             }
             else
             {
-                var poster = Global.RuntimeExp[minute];
+                List<ulong> poster = new List<ulong>();
+                Global.RuntimeExp.TryGetValue(minute, out poster);
                 if(!poster.Contains(message.Author.Id)){
                     poster.Add(message.Author.Id);
                 }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -1,5 +1,4 @@
-﻿using System.Security.Cryptography;
-using System.IO;
+﻿using System.IO;
 using Discord;
 using Discord.Commands;
 using Discord.WebSocket;
@@ -378,9 +377,12 @@ namespace OnePlusBot.Base
                     await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);
 
                     if (result.ErrorReason == "The input text has too few parameters.")
-                    return;
+                    {
+                        return;
+                    }
+                  
 
-                        await context.Channel.SendMessageAsync(result.ErrorReason);
+                    await context.Channel.SendMessageAsync(result.ErrorReason);
                     return;
                  }
                 break;
@@ -624,6 +626,7 @@ namespace OnePlusBot.Base
                     poster.Add(message.Author.Id);
                 }
             }
+            await Task.CompletedTask;
         }
 
         private static async Task OnMessageReceived(SocketMessage message)

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -9,6 +9,7 @@ using System;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
+using Microsoft.EntityFrameworkCore;
 using System.Threading.Tasks;
 using System.Net;
 using System.Collections.Generic;
@@ -32,6 +33,7 @@ namespace OnePlusBot.Base
         {
             _bot.UserJoined += OnuserUserJoined;
             _bot.UserJoined += OnUserJoinedMuteCheck;
+            _bot.UserJoined += OnUserJoinedRole;
             _bot.UserLeft += OnUserLeft;
             _bot.MessageReceived += OnCommandReceived;
             _bot.MessageReceived += OnMessageReceived;
@@ -78,6 +80,21 @@ namespace OnePlusBot.Base
                 if(db.Mutes.Where(us => us.MutedUserID == user.Id && !us.MuteEnded).Any())
                 {
                     await Extensions.MuteUser(user);
+                }
+            }
+        }
+
+        private async Task OnUserJoinedRole(SocketGuildUser user)
+        {
+            using (var db = new Database())
+            {
+                var dbUser = db.Users.Where(us => us.Id == user.Id).Include(us => us.ExperienceRoleReference).FirstOrDefault();
+                if(dbUser != null)
+                {
+                    if(dbUser.ExperienceRoleReference != null){
+                        var role = user.Guild.GetRole(dbUser.ExperienceRoleReference.ExperienceRoleId);
+                        await user.AddRoleAsync(role);
+                    }
                 }
             }
         }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -537,11 +537,11 @@ namespace OnePlusBot.Base
             profanity.Valid = false;
             profanity.ProfanityId = usedProfanity.ID;
             using(var db = new Database()){
-                var user = db.Users.Where(us => us.UserId == message.Author.Id).FirstOrDefault();
+                var user = db.Users.Where(us => us.Id == message.Author.Id).FirstOrDefault();
                 if(user == null)
                 {
                     var newUser = new User();
-                    newUser.UserId = message.Author.Id;
+                    newUser.Id = message.Author.Id;
                     newUser.ModMailMuted = false;
                     db.Users.Add(newUser);
                 }

--- a/src/OnePlusBot/Base/Exception/ConfigurationException.cs
+++ b/src/OnePlusBot/Base/Exception/ConfigurationException.cs
@@ -1,0 +1,13 @@
+namespace OnePlusBot.Base.Errors {
+    [System.Serializable]
+    public class ConfigurationException : System.Exception
+    {
+        public ConfigurationException() { }
+        public ConfigurationException(string message) : base(message) { }
+        public ConfigurationException(string message, System.Exception inner) : base(message, inner) { }
+        protected ConfigurationException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    } 
+}
+

--- a/src/OnePlusBot/Base/Exception/NotFoundException.cs
+++ b/src/OnePlusBot/Base/Exception/NotFoundException.cs
@@ -1,0 +1,13 @@
+namespace OnePlusBot.Base.Errors {
+    [System.Serializable]
+    public class ChannelGroupException : System.Exception
+    {
+        public ChannelGroupException() { }
+        public ChannelGroupException(string message) : base(message) { }
+        public ChannelGroupException(string message, System.Exception inner) : base(message, inner) { }
+        protected ChannelGroupException(
+            System.Runtime.Serialization.SerializationInfo info,
+            System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
+    } 
+}
+

--- a/src/OnePlusBot/Base/Exception/NotFoundException.cs
+++ b/src/OnePlusBot/Base/Exception/NotFoundException.cs
@@ -1,11 +1,11 @@
 namespace OnePlusBot.Base.Errors {
     [System.Serializable]
-    public class ChannelGroupException : System.Exception
+    public class NotFoundException : System.Exception
     {
-        public ChannelGroupException() { }
-        public ChannelGroupException(string message) : base(message) { }
-        public ChannelGroupException(string message, System.Exception inner) : base(message, inner) { }
-        protected ChannelGroupException(
+        public NotFoundException() { }
+        public NotFoundException(string message) : base(message) { }
+        public NotFoundException(string message, System.Exception inner) : base(message, inner) { }
+        protected NotFoundException(
             System.Runtime.Serialization.SerializationInfo info,
             System.Runtime.Serialization.StreamingContext context) : base(info, context) { }
     } 

--- a/src/OnePlusBot/Base/ExpManager.cs
+++ b/src/OnePlusBot/Base/ExpManager.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+using Discord;
 using Discord.Rest;
 using System;
 using System.Threading.Tasks;
@@ -8,7 +8,7 @@ using OnePlusBot.Data;
 using Discord.Commands;
 using Microsoft.EntityFrameworkCore;
 using Discord.WebSocket;
-
+using OnePlusBot.Base.Errors;
 using System.Collections.Generic;
 
 namespace OnePlusBot.Base
@@ -115,10 +115,71 @@ namespace OnePlusBot.Base
       foreach(var userId in userToUpdate){
         var exp = db.Users.Where(e => e.UserId == userId).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
         if(exp != null){
-          exp.XP += (ulong) r.Next(10, 15);
+          exp.XP += (ulong) r.Next(Global.XPGainRangeMin, Global.XPGainRangeMax);
           exp.MessageCount += 1;
           peopleToUpdate.Add(exp);
           exp.Updated = updateDate;
+        }
+      }
+    }
+
+    public async Task UpdateLevelOf(IGuildUser user){
+        var guild = Global.Bot.GetGuild(Global.ServerID);
+        using(var db = new Database()){
+          User userToUpdate = db.Users.Where(us => us.UserId == user.Id).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
+          List<ExperienceRole> rolesUsedInExperience = db.ExperienceRoles.Include(ro => ro.RoleReference).ToList();
+          List<ExperienceLevel> levelConfiguration = db.ExperienceLevels.ToList();
+          List<SocketRole> experienceRolesInGuild = new List<SocketRole>();
+          foreach(ExperienceRole role in rolesUsedInExperience){
+            experienceRolesInGuild.Add(guild.GetRole(role.RoleReference.RoleID));
+          }
+   
+          await UpdateLevelsForUser(userToUpdate, db, guild, rolesUsedInExperience, levelConfiguration, experienceRolesInGuild);
+          db.SaveChanges();
+        }
+    }
+
+    private async Task UpdateLevelsForUser(User user, Database db, 
+                                          SocketGuild guild,
+                                          List<ExperienceRole> rolesUsedInExperience,
+                                          List<ExperienceLevel> levelConfiguration,
+                                          List<SocketRole> experienceRolesInGuild,
+                                          bool delay=false){
+
+       var appropriateLevelForExp = levelConfiguration.Where(lv => lv.NeededExperience <= user.XP).OrderByDescending(lv => lv.Level).FirstOrDefault();
+      // the role may need to be updated, even if the level did not change, when the role config changed, so we need to always enter this if
+      if(appropriateLevelForExp != null){
+        user.Level = appropriateLevelForExp.Level;
+        db.Entry(user).Reference(s => s.CurrentLevel).Load();
+        var appropriateRoleForLevel = rolesUsedInExperience.Where(lv => lv.Level <= user.Level).OrderByDescending(ro => ro.Level).FirstOrDefault();
+        if(appropriateRoleForLevel != null && user.ExperienceRoleId != appropriateRoleForLevel.ExperienceRoleId){
+          user.ExperienceRoleId = appropriateRoleForLevel.Id;
+          db.Entry(user).Reference(s => s.ExperienceRoleReference).Load();
+          db.Entry(user.ExperienceRoleReference).Reference(s => s.RoleReference).Load();
+        }
+      }
+
+      var userInGuild = guild.GetUser(user.UserId);
+      if(userInGuild != null){
+        var experienceRolesTheUserHas = userInGuild.Roles.Intersect(experienceRolesInGuild).ToList();
+        var userHasCorrectRoles = experienceRolesTheUserHas.Count() == 1 && user.ExperienceRoleReference.RoleReference.RoleID == experienceRolesTheUserHas.First().Id;
+        if(!userHasCorrectRoles)
+        {
+          if(experienceRolesTheUserHas.Count() > 0)
+          {
+            await userInGuild.RemoveRolesAsync(experienceRolesInGuild);
+          }
+          if(delay)
+          {
+            await Task.Delay(200);
+          }
+          if(user.ExperienceRoleId != null){
+            var correctExperienceRole = experienceRolesInGuild.Where(role => role.Id == user.ExperienceRoleReference.RoleReference.RoleID).FirstOrDefault();
+            if(correctExperienceRole != null){
+              await userInGuild.AddRoleAsync(correctExperienceRole);
+            }
+          }
+        
         }
       }
     }
@@ -128,46 +189,19 @@ namespace OnePlusBot.Base
         var guild = Global.Bot.GetGuild(Global.ServerID);
         await updateMessage.ModifyAsync(m => m.Content = "0 % Done");
         using(var db = new Database()){
+          List<User> users = db.Users.Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).ToList();
+          var totalUsers = users.Count();
+          var userDone = 0;
           List<ExperienceRole> rolesUsedInExperience = db.ExperienceRoles.Include(ro => ro.RoleReference).ToList();
           List<ExperienceLevel> levelConfiguration = db.ExperienceLevels.ToList();
-          List<User> users = db.Users.Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).ToList();
           List<SocketRole> experienceRolesInGuild = new List<SocketRole>();
           foreach(ExperienceRole role in rolesUsedInExperience){
             experienceRolesInGuild.Add(guild.GetRole(role.RoleReference.RoleID));
           }
-          var totalUsers = users.Count();
-          var userDone = 0;
+   
           foreach(var user in users){
-            var appropriateLevelForExp = levelConfiguration.Where(lv => lv.NeededExperience <= user.XP).OrderByDescending(lv => lv.Level).FirstOrDefault();
-            if(appropriateLevelForExp != null && user.Level != appropriateLevelForExp.Level){
-              user.Level = appropriateLevelForExp.Level;
-              db.Entry(user).Reference(s => s.CurrentLevel).Load();
-              var appropriateRoleForLevel = rolesUsedInExperience.Where(lv => lv.Level <= user.Level).OrderByDescending(ro => ro.Level).FirstOrDefault();
-              if(appropriateRoleForLevel != null && user.ExperienceRoleId != appropriateRoleForLevel.ExperienceRoleId){
-                user.ExperienceRoleId = appropriateRoleForLevel.Id;
-                db.Entry(user).Reference(s => s.ExperienceRoleReference).Load();
-                db.Entry(user.ExperienceRoleReference).Reference(s => s.RoleReference).Load();
-              }
-            }
-
-            var userInGuild = guild.GetUser(user.UserId);
-            if(userInGuild != null){
-              var experienceRolesTheUserHas = userInGuild.Roles.Intersect(experienceRolesInGuild).ToList();
-              var userHasCorrectRoles = experienceRolesTheUserHas.Count() == 1 && user.ExperienceRoleReference.RoleReference.RoleID == experienceRolesTheUserHas.First().Id;
-              if(!userHasCorrectRoles){
-                await Task.Delay(200);
-                if(experienceRolesTheUserHas.Count() > 0){
-                  await userInGuild.RemoveRolesAsync(experienceRolesInGuild);
-                }
-                if(user.ExperienceRoleId != null){
-                  var correctExperienceRole = experienceRolesInGuild.Where(role => role.Id == user.ExperienceRoleReference.RoleReference.RoleID).FirstOrDefault();
-                  if(correctExperienceRole != null){
-                    await userInGuild.AddRoleAsync(correctExperienceRole);
-                  }
-                }
-              
-              }
-            }
+            await UpdateLevelsForUser(user, db, guild, rolesUsedInExperience, levelConfiguration, experienceRolesInGuild, true);
+           
             userDone++;
             if(userDone % (Math.Floor((double) totalUsers / 10)) == 0){
               await updateMessage.ModifyAsync(m => m.Content = $"{Math.Ceiling(((double)userDone / totalUsers) * 100)}% ({userDone}/{totalUsers}) done");
@@ -179,6 +213,69 @@ namespace OnePlusBot.Base
       }).ContinueWith(t => Console.WriteLine(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
      
      
+    }
+
+    public void SetRoleToLevel(uint level, ulong roleId)
+    {
+      using(var db = new Database())
+      {
+        var existingLevel = db.ExperienceRoles.Where(ro => ro.Level == level).FirstOrDefault();
+
+        var existingRole = db.ExperienceRoles.Where(ro => ro.ExperienceRoleId == roleId).FirstOrDefault();
+        var role = db.Roles.Where(r => r.RoleID == roleId).FirstOrDefault();
+        if(role == null || !role.XPRole)
+        {
+          throw new ConfigurationException("Role does not exist or not usable for the xp tracking sytem.");
+        }
+        if(existingLevel != null)
+        {
+          existingLevel.ExperienceRoleId = role.RoleID;
+        }
+        else if(existingRole != null)
+        {
+          existingRole.Level = level;
+        }
+        else
+        {
+          var experienceRole = new ExperienceRole();
+          experienceRole.Level = level;
+          experienceRole.ExperienceRoleId = role.RoleID;
+          db.ExperienceRoles.Add(experienceRole);
+        }
+        db.SaveChanges();
+      }
+    }
+
+    public async Task ShowLevelconfiguration(ISocketMessageChannel channelToRespondIn)
+    {
+      using(var db = new Database())
+      {
+        var guild = Global.Bot.GetGuild(Global.ServerID);
+        var currentEmbedBuilder = new EmbedBuilder().WithTitle("Role level configuration");
+        var embeds = new List<Embed>();
+        var roles = db.ExperienceRoles.OrderBy(ro => ro.Level).Include(ro => ro.RoleReference).ToList();
+        var count = 0;
+        foreach(var role in roles)
+        {
+          count++;
+          currentEmbedBuilder.AddField(role.Level + "", guild.GetRole(role.RoleReference.RoleID).Name);
+            if(((count % EmbedBuilder.MaxFieldCount) == 0) && role != roles.Last()){
+              embeds.Add(currentEmbedBuilder.Build());
+              currentEmbedBuilder = new EmbedBuilder();
+              var currentPage = count / EmbedBuilder.MaxFieldCount + 1;
+              currentEmbedBuilder.WithFooter(new EmbedFooterBuilder().WithText($"Page {currentPage}"));
+            }
+        }
+
+        embeds.Add(currentEmbedBuilder.Build());
+
+        foreach(var embed in embeds)
+        {
+          await channelToRespondIn.SendMessageAsync(embed: embed);
+          await Task.Delay(200);
+        }
+
+      }
     }
   
   }

--- a/src/OnePlusBot/Base/ExpManager.cs
+++ b/src/OnePlusBot/Base/ExpManager.cs
@@ -50,13 +50,16 @@ namespace OnePlusBot.Base
         // they will in the future, anda because they are removed afterwards, this means that there *should* not be anything done twice
         var minutesInThePast = Global.RuntimeExp.Keys.Where(minute => minute <= minuteToPersist);
         List<long> toRemove = new List<long>();
-        if(minutesInThePast.Any()){
-          foreach(var processedMinute in minutesInThePast){
+        if(minutesInThePast.Any())
+        {
+          foreach(var processedMinute in minutesInThePast)
+          {
             UpdateExperienceForMinute(Global.RuntimeExp[processedMinute], db, peopleToUpdate, rnd);
             toRemove.Add(processedMinute);
           }
         }
-        foreach(var minuteToRemove in toRemove){
+        foreach(var minuteToRemove in toRemove)
+        {
           Global.RuntimeExp.TryRemove(minuteToRemove, out _);
         }
         db.SaveChanges();
@@ -77,19 +80,25 @@ namespace OnePlusBot.Base
           {
             var guild = Global.Bot.GetGuild(Global.ServerID);
             var rolesGiven = new Dictionary<ulong, Discord.IRole>();
-            foreach(var person in peopleWhoChangedLevel){
+            foreach(var person in peopleWhoChangedLevel)
+            {
               var roleSegment = GetAppropriateRoleForLevel(person.CurrentLevel, db);
               // null in case of first role
-              if(roleSegment != null){
-                if(roleSegment.ExperienceRoleId != person.ExperienceRoleId){
-                  if(!rolesGiven.ContainsKey(roleSegment.RoleReference.RoleID)){
+              if(roleSegment != null)
+              {
+                if(roleSegment.ExperienceRoleId != person.ExperienceRoleId)
+                {
+                  if(!rolesGiven.ContainsKey(roleSegment.RoleReference.RoleID))
+                  {
                     rolesGiven.Add(roleSegment.RoleReference.RoleID, guild.GetRole(roleSegment.RoleReference.RoleID));
                   }
                   ulong existingDiscordRoleFromUser = 0;
-                  if(person.ExperienceRoleReference != null){
+                  if(person.ExperienceRoleReference != null)
+                  {
                     existingDiscordRoleFromUser = person.ExperienceRoleReference.RoleReference.RoleID;
                 
-                    if(!rolesGiven.ContainsKey(existingDiscordRoleFromUser)){
+                    if(!rolesGiven.ContainsKey(existingDiscordRoleFromUser))
+                    {
                       rolesGiven.Add(existingDiscordRoleFromUser, guild.GetRole(existingDiscordRoleFromUser));
                     }
                   }
@@ -97,10 +106,10 @@ namespace OnePlusBot.Base
                 
                   person.ExperienceRoleId = roleSegment.Id;
                   var user = guild.GetUser(person.Id);
-                  if(existingDiscordRoleFromUser != 0){
+                  if(existingDiscordRoleFromUser != 0)
+                  {
                     await user.RemoveRoleAsync(rolesGiven[existingDiscordRoleFromUser]);
                   }
-                  
                  
                   await user.AddRoleAsync(rolesGiven[roleSegment.RoleReference.RoleID]);
                 }
@@ -110,26 +119,30 @@ namespace OnePlusBot.Base
         }
 
         db.SaveChanges();
-        
-       
       }
     }
      
-    public ExperienceLevel GetAppropriateLevelForExp(ulong xp, Database db){
+    public ExperienceLevel GetAppropriateLevelForExp(ulong xp, Database db)
+    {
       return db.ExperienceLevels.Where(lv => lv.NeededExperience <= xp).OrderByDescending(lv => lv.Level).FirstOrDefault();
     }
 
-    public ExperienceRole GetAppropriateRoleForLevel(ExperienceLevel level, Database db){
+    public ExperienceRole GetAppropriateRoleForLevel(ExperienceLevel level, Database db)
+    {
       return db.ExperienceRoles.Where( ro => ro.Level <= level.Level).Include(ro => ro.RoleReference).OrderByDescending(ro => ro.Level).FirstOrDefault();
     }
 
-    public void UpdateExperienceForMinute(List<ulong> userToUpdate, Database db, HashSet<User> peopleToUpdate, Random r){
+    public void UpdateExperienceForMinute(List<ulong> userToUpdate, Database db, HashSet<User> peopleToUpdate, Random r)
+    {
       var updateDate = DateTime.Now;
-      foreach(var userId in userToUpdate){
+      foreach(var userId in userToUpdate)
+      {
         var exp = db.Users.Where(e => e.Id == userId).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
         var gainedExp = (ulong) r.Next(Global.XPGainRangeMin, Global.XPGainRangeMax);
-        if(exp != null){
-          if(exp.XPGainDisabled) {
+        if(exp != null)
+        {
+          if(exp.XPGainDisabled) 
+          {
             continue;
           }
           exp.XP += gainedExp;
@@ -147,7 +160,7 @@ namespace OnePlusBot.Base
           newUser.ModMailMutedUntil = DateTime.Now;
           newUser.XPGainDisabled = false;
           newUser.Level = 0;
-          newUser.MessageCount += 1;
+          newUser.MessageCount = 1;
           newUser.XP = gainedExp;
           newUser.Updated = updateDate;
           db.Users.Add(newUser);
@@ -156,9 +169,11 @@ namespace OnePlusBot.Base
       }
     }
 
-    public async Task UpdateLevelOf(IGuildUser user){
+    public async Task UpdateLevelOf(IGuildUser user)
+    {
         var guild = Global.Bot.GetGuild(Global.ServerID);
-        using(var db = new Database()){
+        using(var db = new Database())
+        {
           User userToUpdate = db.Users.Where(us => us.Id == user.Id).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
           List<ExperienceRole> rolesUsedInExperience = db.ExperienceRoles.Include(ro => ro.RoleReference).ToList();
           List<ExperienceLevel> levelConfiguration = db.ExperienceLevels.ToList();
@@ -178,27 +193,33 @@ namespace OnePlusBot.Base
                                           List<ExperienceRole> rolesUsedInExperience,
                                           List<ExperienceLevel> levelConfiguration,
                                           List<SocketRole> experienceRolesInGuild,
-                                          bool delay=false){
+                                          bool delay=false)
+                                          {
 
-       var appropriateLevelForExp = levelConfiguration.Where(lv => lv.NeededExperience <= user.XP).OrderByDescending(lv => lv.Level).FirstOrDefault();
+      var appropriateLevelForExp = levelConfiguration.Where(lv => lv.NeededExperience <= user.XP).OrderByDescending(lv => lv.Level).FirstOrDefault();
       // the role may need to be updated, even if the level did not change, when the role config changed, so we need to always enter this if
-      if(appropriateLevelForExp != null){
+      if(appropriateLevelForExp != null)
+      {
         user.Level = appropriateLevelForExp.Level;
         db.Entry(user).Reference(s => s.CurrentLevel).Load();
         var appropriateRoleForLevel = rolesUsedInExperience.Where(lv => lv.Level <= user.Level).OrderByDescending(ro => ro.Level).FirstOrDefault();
-        if(appropriateRoleForLevel != null && user.ExperienceRoleId != appropriateRoleForLevel.ExperienceRoleId){
+        if(appropriateRoleForLevel != null && user.ExperienceRoleId != appropriateRoleForLevel.ExperienceRoleId)
+        {
           user.ExperienceRoleId = appropriateRoleForLevel.Id;
           db.Entry(user).Reference(s => s.ExperienceRoleReference).Load();
           db.Entry(user.ExperienceRoleReference).Reference(s => s.RoleReference).Load();
         }
-      } else {
+      }
+      else 
+      {
         user.Level = 0;
         user.ExperienceRoleId = null;
         db.Entry(user).Reference(s => s.ExperienceRoleReference).Load();
       }
 
       var userInGuild = guild.GetUser(user.Id);
-      if(userInGuild != null){
+      if(userInGuild != null)
+      {
         var experienceRolesTheUserHas = userInGuild.Roles.Intersect(experienceRolesInGuild).ToList();
         if(user.ExperienceRoleReference == null)
         {
@@ -217,9 +238,11 @@ namespace OnePlusBot.Base
             {
               await Task.Delay(200);
             }
-            if(user.ExperienceRoleId != null){
+            if(user.ExperienceRoleId != null)
+            {
               var correctExperienceRole = experienceRolesInGuild.Where(role => role.Id == user.ExperienceRoleReference.RoleReference.RoleID).FirstOrDefault();
-              if(correctExperienceRole != null){
+              if(correctExperienceRole != null)
+              {
                 await userInGuild.AddRoleAsync(correctExperienceRole);
               }
             }
@@ -231,25 +254,30 @@ namespace OnePlusBot.Base
     }
 
     public void UpdateLevelsOfMembers(RestUserMessage updateMessage){
-      Task.Run(async () => {
+      Task.Run(async () => 
+      {
         var guild = Global.Bot.GetGuild(Global.ServerID);
         await updateMessage.ModifyAsync(m => m.Content = "0 % Done");
-        using(var db = new Database()){
+        using(var db = new Database())
+        {
           List<User> users = db.Users.Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).ToList();
           var totalUsers = users.Count();
           var userDone = 0;
           List<ExperienceRole> rolesUsedInExperience = db.ExperienceRoles.Include(ro => ro.RoleReference).ToList();
           List<ExperienceLevel> levelConfiguration = db.ExperienceLevels.ToList();
           List<SocketRole> experienceRolesInGuild = new List<SocketRole>();
-          foreach(ExperienceRole role in rolesUsedInExperience){
+          foreach(ExperienceRole role in rolesUsedInExperience)
+          {
             experienceRolesInGuild.Add(guild.GetRole(role.RoleReference.RoleID));
           }
    
-          foreach(var user in users){
+          foreach(var user in users)
+          {
             await UpdateLevelsForUser(user, db, guild, rolesUsedInExperience, levelConfiguration, experienceRolesInGuild, true);
            
             userDone++;
-            if(userDone % (Math.Floor((double) totalUsers / 10)) == 0){
+            if(userDone % (Math.Floor((double) totalUsers / 10)) == 0)
+            {
               await updateMessage.ModifyAsync(m => m.Content = $"{Math.Ceiling(((double)userDone / totalUsers) * 100)}% ({userDone}/{totalUsers}) done");
             }
             db.SaveChanges();
@@ -305,7 +333,8 @@ namespace OnePlusBot.Base
         {
           count++;
           currentEmbedBuilder.AddField(guild.GetRole(role.RoleReference.RoleID).Name, role.Level + "", true);
-            if(((count % EmbedBuilder.MaxFieldCount) == 0) && role != roles.Last()){
+            if(((count % EmbedBuilder.MaxFieldCount) == 0) && role != roles.Last())
+            {
               embeds.Add(currentEmbedBuilder.Build());
               currentEmbedBuilder = new EmbedBuilder();
               var currentPage = count / EmbedBuilder.MaxFieldCount + 1;

--- a/src/OnePlusBot/Base/ExpManager.cs
+++ b/src/OnePlusBot/Base/ExpManager.cs
@@ -83,7 +83,7 @@ namespace OnePlusBot.Base
                   
                 
                   person.ExperienceRoleId = roleSegment.Id;
-                  var user = guild.GetUser(person.UserId);
+                  var user = guild.GetUser(person.Id);
                   if(existingDiscordRoleFromUser != 0){
                     await user.RemoveRoleAsync(rolesGiven[existingDiscordRoleFromUser]);
                   }
@@ -113,7 +113,7 @@ namespace OnePlusBot.Base
     public void UpdateExperienceForMinute(List<ulong> userToUpdate, Database db, HashSet<User> peopleToUpdate, Random r){
       var updateDate = DateTime.Now;
       foreach(var userId in userToUpdate){
-        var exp = db.Users.Where(e => e.UserId == userId).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
+        var exp = db.Users.Where(e => e.Id == userId).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
         if(exp != null){
           exp.XP += (ulong) r.Next(Global.XPGainRangeMin, Global.XPGainRangeMax);
           exp.MessageCount += 1;
@@ -126,7 +126,7 @@ namespace OnePlusBot.Base
     public async Task UpdateLevelOf(IGuildUser user){
         var guild = Global.Bot.GetGuild(Global.ServerID);
         using(var db = new Database()){
-          User userToUpdate = db.Users.Where(us => us.UserId == user.Id).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
+          User userToUpdate = db.Users.Where(us => us.Id == user.Id).Include(u => u.ExperienceRoleReference).ThenInclude(u => u.RoleReference).FirstOrDefault();
           List<ExperienceRole> rolesUsedInExperience = db.ExperienceRoles.Include(ro => ro.RoleReference).ToList();
           List<ExperienceLevel> levelConfiguration = db.ExperienceLevels.ToList();
           List<SocketRole> experienceRolesInGuild = new List<SocketRole>();
@@ -159,7 +159,7 @@ namespace OnePlusBot.Base
         }
       }
 
-      var userInGuild = guild.GetUser(user.UserId);
+      var userInGuild = guild.GetUser(user.Id);
       if(userInGuild != null){
         var experienceRolesTheUserHas = userInGuild.Roles.Intersect(experienceRolesInGuild).ToList();
         var userHasCorrectRoles = experienceRolesTheUserHas.Count() == 1 && user.ExperienceRoleReference.RoleReference.RoleID == experienceRolesTheUserHas.First().Id;

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -20,6 +20,8 @@ namespace OnePlusBot.Base
         public static Dictionary<string, ulong> Roles { get; }
         public static Dictionary<string, ulong> Channels { get; }
 
+        public static Dictionary<string, ulong> PostTargets { get; }
+
         public static Dictionary<ulong, ulong> NewsPosts { get; }
         public static List<Channel> FullChannels { get; }
 
@@ -44,6 +46,8 @@ namespace OnePlusBot.Base
         public static List<StarboardMessage> StarboardPosts { get; set; }
 
         public static List<Char> IllegalUserNameBeginnings { get; set; }
+
+        public static Dictionary<long, List<ulong>> RuntimeExp { get; set; }
         
         public static string Token
         {
@@ -93,6 +97,7 @@ namespace OnePlusBot.Base
         static Global()
         {
             Channels = new Dictionary<string, ulong>();
+            PostTargets = new Dictionary<string, ulong>();
             FullChannels = new List<Channel>();
             Random = new Random();
             NewsPosts = new Dictionary<ulong, ulong>();  
@@ -104,6 +109,7 @@ namespace OnePlusBot.Base
             InviteLinks = new List<InviteLink>();
             ModMailThreads = new List<ModMailThread>();
             ReportedProfanities = new List<UsedProfanity>();
+            RuntimeExp = new Dictionary<long, List<ulong>>();
             LoadGlobal();
         }
 
@@ -124,12 +130,21 @@ namespace OnePlusBot.Base
                
                 Channels.Clear();
                 FullChannels.Clear();
-                if (db.Channels.Any())
+                if (db.Channels.Any()) 
+                {
                     foreach (var channel in db.Channels)
                     {
-                        Channels.Add(channel.Name, channel.ChannelID);
+                        Channels.Add(channel.Name, channel.ChannelID2);
                         FullChannels.Add(channel);
                     }
+                }
+
+                PostTargets.Clear();
+                foreach(var target in db.PostTargets)
+                {
+                    PostTargets.Add(target.Name, target.ChannelId);
+                }
+                   
                        
                 Roles.Clear();
                 if (db.Roles.Any())
@@ -196,10 +211,6 @@ namespace OnePlusBot.Base
 
 
                 var ReadChannels = db.FAQCommandChannels
-                        .Include(faqComand => faqComand.Command)
-                        .Include(faqComand => faqComand.Channel)
-                        .Include(faqComand => faqComand.CommandChannelEntries)
-                        .OrderBy(command => command.Command.ID)
                         .ToList();
 
                 FAQCommands.Clear();
@@ -213,7 +224,7 @@ namespace OnePlusBot.Base
         }
 
         public static class OnePlusEmote {
-            public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
+            public static IEmote SUCCESS = Emote.Parse("<:snow_avasnow_avasnow_avasnow_ava:604671718254182411>");
             public static IEmote FAIL = new Emoji("⚠");
             public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
             public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -50,6 +50,10 @@ namespace OnePlusBot.Base
         public static Dictionary<long, List<ulong>> RuntimeExp { get; set; }
 
         public static bool XPGainDisabled { get; set; }
+
+        public static int XPGainRangeMin { get; set; }
+
+        public static int XPGainRangeMax { get; set; }
         
         public static string Token
         {
@@ -196,6 +200,13 @@ namespace OnePlusBot.Base
                     .First(entry => entry.Name == "modmail_category_id")
                     .Value;
 
+                XPGainRangeMin = (int) db.PersistentData
+                    .First(entry => entry.Name == "xp_gain_range_min")
+                    .Value;
+
+                XPGainRangeMax = (int) db.PersistentData
+                    .First(entry => entry.Name == "xp_gain_range_max")
+                    .Value;
 
                 StarboardPosts.Clear();
                 if(db.StarboardMessages.Any())

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -247,7 +247,7 @@ namespace OnePlusBot.Base
         }
 
         public static class OnePlusEmote {
-            public static IEmote SUCCESS = Emote.Parse("<:snow_avasnow_avasnow_avasnow_ava:604671718254182411>");
+            public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
             public static IEmote FAIL = new Emoji("⚠");
             public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
             public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -7,6 +7,7 @@ using OnePlusBot.Data.Models;
 using Microsoft.EntityFrameworkCore;
 using Discord.WebSocket;
 using System.Text.RegularExpressions;
+using System.Collections.Concurrent;
 
 namespace OnePlusBot.Base
 {
@@ -47,7 +48,7 @@ namespace OnePlusBot.Base
 
         public static List<Char> IllegalUserNameBeginnings { get; set; }
 
-        public static Dictionary<long, List<ulong>> RuntimeExp { get; set; }
+        public static ConcurrentDictionary<long, List<ulong>> RuntimeExp { get; set; }
 
         public static bool XPGainDisabled { get; set; }
 
@@ -115,7 +116,7 @@ namespace OnePlusBot.Base
             InviteLinks = new List<InviteLink>();
             ModMailThreads = new List<ModMailThread>();
             ReportedProfanities = new List<UsedProfanity>();
-            RuntimeExp = new Dictionary<long, List<ulong>>();
+            RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
             LoadGlobal();
         }
 

--- a/src/OnePlusBot/Base/ModMailManager.cs
+++ b/src/OnePlusBot/Base/ModMailManager.cs
@@ -25,7 +25,7 @@ namespace OnePlusBot.Base
                 await message.Channel.SendMessageAsync($"You are unable to contact modmail until {userFromCache.ThreadUser.ModMailMutedUntil:dd.MM.yyyy HH:mm} {TimeZoneInfo.Local}.");
                 using(var db = new Database())
                 {
-                    db.Users.Where(us => us.UserId == message.Author.Id).First().ModMailMutedReminded = true;
+                    db.Users.Where(us => us.Id == message.Author.Id).First().ModMailMutedReminded = true;
                     db.SaveChanges();
                 }
 
@@ -36,11 +36,11 @@ namespace OnePlusBot.Base
 
         using(var db = new Database())
         {
-            var user = db.Users.Where(us => us.UserId == message.Author.Id).FirstOrDefault();
+            var user = db.Users.Where(us => us.Id == message.Author.Id).FirstOrDefault();
             if(user == null)
             {
                 var newUser = new User();
-                newUser.UserId = message.Author.Id;
+                newUser.Id = message.Author.Id;
                 newUser.ModMailMuted = false;
                 db.Users.Add(newUser);
                 db.SaveChanges();
@@ -335,7 +335,7 @@ namespace OnePlusBot.Base
         var guild = bot.GetGuild(Global.ServerID);
         using(var db = new Database()){
             var thread = db.ModMailThreads.Where(ch => ch.ChannelId == channel.Id).First();
-            var user = db.Users.Where(us => us.UserId == thread.UserId).First();
+            var user = db.Users.Where(us => us.Id == thread.UserId).First();
             user.ModMailMuted = true;
             user.ModMailMutedReminded = false;
             user.ModMailMutedUntil = until;
@@ -349,10 +349,10 @@ namespace OnePlusBot.Base
         var bot = Global.Bot;
         var guild = bot.GetGuild(Global.ServerID);
         using(var db = new Database()){
-            var userInDb = db.Users.Where(us => us.UserId == user.Id).FirstOrDefault();
+            var userInDb = db.Users.Where(us => us.Id == user.Id).FirstOrDefault();
             if(userInDb == null){
                 var newUser = new User();
-                newUser.UserId = user.Id;
+                newUser.Id = user.Id;
                 newUser.ModMailMuted = true;
                 newUser.ModMailMutedReminded = false;
                 newUser.ModMailMutedUntil = until;
@@ -396,7 +396,7 @@ namespace OnePlusBot.Base
     public void EnableModmailForUser(IGuildUser user)
     {
         using(var db = new Database()){
-            var userInDb = db.Users.Where(us => us.UserId == user.Id).First();
+            var userInDb = db.Users.Where(us => us.Id == user.Id).First();
             userInDb.ModMailMuted = false;
             db.SaveChanges();
         }
@@ -412,11 +412,11 @@ namespace OnePlusBot.Base
                 return;
             }
 
-            var existingUser = db.Users.Where(us => us.UserId == user.Id).FirstOrDefault();
+            var existingUser = db.Users.Where(us => us.Id == user.Id).FirstOrDefault();
             if(existingUser == null)
             {
                 var newUser = new User();
-                newUser.UserId = user.Id;
+                newUser.Id = user.Id;
                 newUser.ModMailMuted = false;
                 db.Users.Add(newUser);
             }

--- a/src/OnePlusBot/Base/ModMailManager.cs
+++ b/src/OnePlusBot/Base/ModMailManager.cs
@@ -67,7 +67,7 @@ namespace OnePlusBot.Base
             modmailThread = db.ModMailThreads.Where(th => th.ChannelId == channel.Id).First(); 
         }
 
-        var modQueue = guild.GetTextChannel(Global.Channels["modqueue"]);
+        var modQueue = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_NOTIFICATION]);
         var staffRole = guild.GetRole(Global.Roles["staff"]);
         await staffRole.ModifyAsync(x => x.Mentionable = true);
         try 
@@ -237,7 +237,7 @@ namespace OnePlusBot.Base
         {
             messagesToLog = db.ThreadMessages.Where(ch => ch.ChannelId == closedthread.ChannelId).ToList();
         }
-        var modMailLogChannel = guild.GetTextChannel(Global.Channels["modmaillog"]);
+        var modMailLogChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_LOG]);
         await LogClosingHeader(closedthread, messagesToLog.Count(), note, modMailLogChannel, userObj);
 
         await LogModMailThreadMessagesToModmailLog(closedthread, note, messagesToLog, modMailLogChannel);
@@ -381,7 +381,7 @@ namespace OnePlusBot.Base
         {
             messagesToLog = db.ThreadMessages.Where(ch => ch.ChannelId == closedthread.ChannelId).ToList();
         }
-        var modMailLogChannel = guild.GetTextChannel(Global.Channels["modmaillog"]);
+        var modMailLogChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_LOG]);
         await LogDisablingHeader(closedthread, messagesToLog.Count(), note, modMailLogChannel, userObj, until);
 
         await LogModMailThreadMessagesToModmailLog(closedthread, note, messagesToLog, modMailLogChannel);

--- a/src/OnePlusBot/Base/ModMailManager.cs
+++ b/src/OnePlusBot/Base/ModMailManager.cs
@@ -395,7 +395,8 @@ namespace OnePlusBot.Base
 
     public void EnableModmailForUser(IGuildUser user)
     {
-        using(var db = new Database()){
+        using(var db = new Database())
+        {
             var userInDb = db.Users.Where(us => us.Id == user.Id).First();
             userInDb.ModMailMuted = false;
             db.SaveChanges();

--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -114,7 +114,7 @@ namespace OnePlusBot.Base
                         .AddField("Mute Id", muteId)
                         .AddField("Mute duration", Extensions.FormatTimeSpan(DateTime.Now - muteObj.MuteDate))
                         .AddField("Muted since", $"{ muteObj.MuteDate:dd.MM.yyyy HH:mm}");
-            await guild.GetTextChannel(Global.Channels["mutes"]).SendMessageAsync(embed: noticeEmbed.Build());
+            await guild.GetTextChannel(Global.PostTargets[PostTarget.MUTE_LOG]).SendMessageAsync(embed: noticeEmbed.Build());
           }
         }
         db.SaveChanges();

--- a/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
+++ b/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
@@ -17,27 +17,32 @@ namespace OnePlusBot.Base
         }
         public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
         {
+            var emoteMatched = false;
             using(var db = new Database())
             {
+                
                 var profanity = db.Profanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault();
                 if(profanity != null)
                 {
                     if(reaction.Emote.Name == Global.OnePlusEmote.OP_NO.Name)
                     {
                         profanity.Valid = false;
+                        emoteMatched = true;
                     }
                     else if(reaction.Emote.Name == Global.OnePlusEmote.OP_YES.Name)
                     {
                         profanity.Valid = true;
+                        emoteMatched = true;
                     }
                     db.SaveChanges();
                 }
             }
             var prof = Global.ReportedProfanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault();
-            if(prof != null)
+            if(prof != null && emoteMatched)
             {
                 Global.ReportedProfanities.Remove(prof);
             }
+            await Task.CompletedTask;
         }
     }
 }

--- a/src/OnePlusBot/Base/RequireRole.cs
+++ b/src/OnePlusBot/Base/RequireRole.cs
@@ -1,3 +1,4 @@
+using System.Runtime.CompilerServices;
 using System.Linq;
 using System;
 using System.Threading.Tasks;
@@ -9,24 +10,74 @@ using Discord;
 namespace OnePlusBot.Base
 {
 
+    public enum ConcatenationMode {
+      AND, OR
+    }
+
     public class RequireRole : PreconditionAttribute
     {
-        private readonly string AllowedRole;
+        public readonly string[] AllowedRoles;
+
+        public ConcatenationMode mode;
 
         // this is executed very early in the lifecycle, we dont have a server object or bot object yet
-        public RequireRole(string name) => this.AllowedRole = name;
+        public RequireRole(params string[] names) : this(names, ConcatenationMode.OR)
+        {
+        }
+
+        public RequireRole(string[] names, ConcatenationMode mode)
+        {
+          this.AllowedRoles = names;
+          this.mode = mode;
+        }
+
+        public RequireRole(string name, ConcatenationMode mode)
+        {
+          this.AllowedRoles = new string[] { name };
+          this.mode = mode;
+        }
+
+        public RequireRole(string name) : this(name, ConcatenationMode.OR)
+        {
+        }
+
 
         public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             var bot = Global.Bot;
             var guild = bot.GetGuild(Global.ServerID);
             var iGuildObj = (IGuild) guild;
-            var allowedroleObj =  iGuildObj.GetRole(Global.Roles[AllowedRole]);
             var user = (SocketGuildUser) context.User;
-            if(user.Roles.Any(role => role.Id == allowedroleObj.Id)){
-                return Task.FromResult(PreconditionResult.FromSuccess());
-            } 
-            return Task.FromResult(PreconditionResult.FromError($"You need the role {this.AllowedRole} to perform this command."));
+            bool allowed = mode == ConcatenationMode.AND;
+            foreach(string roleName in AllowedRoles)
+            {
+              var allowedroleObj =  iGuildObj.GetRole(Global.Roles[roleName]);
+              var hasRole = user.Roles.Where(role => role.Id == allowedroleObj.Id).Any();
+              if(mode == ConcatenationMode.AND)
+              {
+                if(!hasRole)
+                {
+                  allowed = false;
+                  break;
+                } 
+              }
+              else
+              {
+                if(hasRole)
+                {
+                  allowed = true;
+                  break;
+                }
+              }
+            }
+            if(allowed)
+            {
+              return Task.FromResult(PreconditionResult.FromSuccess());
+            }
+            else
+            {
+              return Task.FromResult(PreconditionResult.FromError("You lack the necessary role(s) to perform this command."));
+            }
         }
     }
 }

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -31,7 +31,7 @@ namespace OnePlusBot.Base
             
             var currentStarReaction = message.Reactions.Where(re => re.Key.Name == reaction.Emote.Name).DefaultIfEmpty().First();
 
-            var starboardChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.STARBOARD];);
+            var starboardChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.STARBOARD]);
             var existingPostList = Global.StarboardPosts.Where(msg => msg.MessageId == message.Id);
 
             var starCount = await this.GetTrueStarCount(message, currentStarReaction);

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -31,7 +31,7 @@ namespace OnePlusBot.Base
             
             var currentStarReaction = message.Reactions.Where(re => re.Key.Name == reaction.Emote.Name).DefaultIfEmpty().First();
 
-            var starboardChannel = guild.GetTextChannel(Global.Channels["starboard"]);
+            var starboardChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.STARBOARD];);
             var existingPostList = Global.StarboardPosts.Where(msg => msg.MessageId == message.Id);
 
             var starCount = await this.GetTrueStarCount(message, currentStarReaction);

--- a/src/OnePlusBot/Base/WarningDecayTimerManager.cs
+++ b/src/OnePlusBot/Base/WarningDecayTimerManager.cs
@@ -98,7 +98,7 @@ namespace OnePlusBot.Base
           Timestamp = DateTime.Now
         };
 
-        await guild.GetTextChannel(Global.Channels["decaylog"]).SendMessageAsync(embed: embed.Build());
+        await guild.GetTextChannel(Global.PostTargets[PostTarget.DECAY_LOG]).SendMessageAsync(embed: embed.Build());
         await Task.Delay(1000);
         counter++;
       }

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -42,6 +42,16 @@ namespace OnePlusBot.Data
 
         public DbSet<InviteLink> InviteLinks { get; set; }
 
+        public DbSet<ExperienceLevel> ExperienceLevels { get; set; }
+
+        public DbSet<ExperienceRole> ExperienceRoles { get; set; }
+
+        public DbSet<PostTarget> PostTargets { get; set; }
+
+        public DbSet<ChannelGroup> ChannelGroups { get; set; }
+
+        public DbSet<ChannelInGroup> ChannelGroupMembers { get; set; }
+
         // TODO needs to be replaced with proper dependency injection
         [Obsolete]
         public static readonly LoggerFactory LoggerFactory
@@ -80,6 +90,8 @@ namespace OnePlusBot.Data
             modelBuilder.Entity<StarboardPostRelation>().HasKey(c => new { c.MessageId, c.UserId });
             modelBuilder.Entity<ThreadSubscriber>().HasKey(c => new { c.UserId, c.ModMailThreadId });
             modelBuilder.Entity<ThreadMessage>().HasKey(c => new { c.ChannelId, c.ChannelMessageId });
+            modelBuilder.Entity<ChannelInGroup>().HasKey(c => new {c.ChannelId, c.ChannelGroupId});
+            modelBuilder.Entity<PostTarget>().HasIndex(p => p.Name).IsUnique();
         }
 
     }

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -9,17 +9,13 @@ namespace OnePlusBot.Data.Models
     [Table("Channels")]
     public class Channel
     {
-        [Key]
-        [Column("id")]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        [Obsolete("Are you sure you don't want to use ChannelID?")]
-        public uint ID { get; set; }
-        
+       
         [Column("name")]
         public string Name { get; set; }
 
         [Column("channel_id")]
-        public ulong ChannelID { get; set; }
+        [Key]
+        public ulong ChannelID2 { get; set; }
         
         [Column("channel_type")]
         public ChannelType ChannelType { get; set; }
@@ -31,6 +27,13 @@ namespace OnePlusBot.Data.Models
         public bool InviteCheckExempt{ get; set;}
 
         public virtual ICollection<FAQCommandChannel> CommandChannels { get; set; }
+
+        public static readonly string STARBOARD = "starboard";
+        public static readonly string REFERRAL = "referralcodes";
+
+        public static readonly string SETUPS = "setups";
+        public static readonly string INFO = "info";
+        
 
     }
 }

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -1,3 +1,4 @@
+using System.Linq;
 using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
@@ -15,18 +16,27 @@ namespace OnePlusBot.Data.Models
 
         [Column("channel_id")]
         [Key]
-        public ulong ChannelID2 { get; set; }
+        public ulong ChannelID { get; set; }
         
         [Column("channel_type")]
         public ChannelType ChannelType { get; set; }
 
-        [Column("profanity_check_exempt")]
-        public bool ProfanityCheckExempt{ get; set;}
+        public virtual ICollection<ChannelInGroup> GroupsChannelIsIn { get; set; }
 
-        [Column("invite_check_exempt")]
-        public bool InviteCheckExempt{ get; set;}
+        public bool ProfanityExempt()
+        {
+            return this.GroupsChannelIsIn.Where(grp => grp.Group.ProfanityCheckExempt && !grp.Group.Disabled).FirstOrDefault() != null;
+        }
 
-        public virtual ICollection<FAQCommandChannel> CommandChannels { get; set; }
+        public bool InviteCheckExempt()
+        {
+            return this.GroupsChannelIsIn.Where(grp => grp.Group.InviteCheckExempt && !grp.Group.Disabled).FirstOrDefault() != null;
+        }
+
+        public bool ExperienceGainExempt()
+        {
+            return this.GroupsChannelIsIn.Where(grp => grp.Group.ExperienceGainExempt && !grp.Group.Disabled).FirstOrDefault() != null;
+        }
 
         public static readonly string STARBOARD = "starboard";
         public static readonly string REFERRAL = "referralcodes";

--- a/src/OnePlusBot/Data/Models/ChannelGroup.cs
+++ b/src/OnePlusBot/Data/Models/ChannelGroup.cs
@@ -1,7 +1,5 @@
-using System;
 using System.ComponentModel.DataAnnotations;
 using System.ComponentModel.DataAnnotations.Schema;
-using Discord;
 using System.Collections.Generic;
 
 namespace OnePlusBot.Data.Models
@@ -15,6 +13,18 @@ namespace OnePlusBot.Data.Models
         
         [Column("name")]
         public string Name { get; set; }
+
+        [Column("profanity_check_exempt")]
+        public bool ProfanityCheckExempt { get; set;}
+
+        [Column("invite_check_exempt")]
+        public bool InviteCheckExempt { get; set;}
+
+        [Column("exp_gain_exempt")]
+        public bool ExperienceGainExempt { get; set; }
+
+        [Column("disabled")]
+        public bool Disabled { get; set; }
 
 
         public virtual ICollection<ChannelInGroup> Channels { get; set; }

--- a/src/OnePlusBot/Data/Models/ChannelGroup.cs
+++ b/src/OnePlusBot/Data/Models/ChannelGroup.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("ChannelGroups")]
+    public class ChannelGroup
+    {
+        [Column("id")]
+        [Key]
+        public uint Id { get; set; }
+        
+        [Column("name")]
+        public string Name { get; set; }
+
+
+        public virtual ICollection<ChannelInGroup> Channels { get; set; }
+      
+    }
+}

--- a/src/OnePlusBot/Data/Models/ChannelInGroup.cs
+++ b/src/OnePlusBot/Data/Models/ChannelInGroup.cs
@@ -17,6 +17,9 @@ namespace OnePlusBot.Data.Models
 
         [ForeignKey("ChannelGroupId")]
         public virtual ChannelGroup Group { get; set; }
+
+        [ForeignKey("ChannelId")]
+        public virtual Channel ChannelReference { get; set; }
       
     }
 }

--- a/src/OnePlusBot/Data/Models/ChannelInGroup.cs
+++ b/src/OnePlusBot/Data/Models/ChannelInGroup.cs
@@ -1,0 +1,22 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("ChannelInGroup")]
+    public class ChannelInGroup
+    {
+        [Column("channel_id")]
+        public ulong ChannelId { get; set; }
+        
+        [Column("channel_group_id")]
+        public uint ChannelGroupId { get; set; }
+
+        [ForeignKey("ChannelGroupId")]
+        public virtual ChannelGroup Group { get; set; }
+      
+    }
+}

--- a/src/OnePlusBot/Data/Models/ExperienceLevels.cs
+++ b/src/OnePlusBot/Data/Models/ExperienceLevels.cs
@@ -1,0 +1,20 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("ExperienceLevels")]
+    public class ExperienceLevel
+    {
+        [Column("level")]
+        [Key]
+        public uint Level { get; set; }
+        
+        [Column("needed_experience")]
+        public ulong NeededExperience { get; set; }
+      
+    }
+}

--- a/src/OnePlusBot/Data/Models/ExperienceRoles.cs
+++ b/src/OnePlusBot/Data/Models/ExperienceRoles.cs
@@ -14,7 +14,7 @@ namespace OnePlusBot.Data.Models
         public uint Id { get; set; }
 
         [Column("role_id")]
-        public uint ExperienceRoleId { get; set; }
+        public ulong ExperienceRoleId { get; set; }
         
         [Column("level")]
         public uint Level { get; set; }

--- a/src/OnePlusBot/Data/Models/ExperienceRoles.cs
+++ b/src/OnePlusBot/Data/Models/ExperienceRoles.cs
@@ -1,0 +1,29 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("ExperienceRoles")]
+    public class ExperienceRole
+    {
+        [Column("id")]
+        [Key]
+        public uint Id { get; set; }
+
+        [Column("role_id")]
+        public uint ExperienceRoleId { get; set; }
+        
+        [Column("level")]
+        public uint Level { get; set; }
+      
+        [ForeignKey("ExperienceRoleId")]
+        public virtual Role RoleReference { get; set; }
+
+        [ForeignKey("Level")]
+        public virtual ExperienceLevel LevelReference { get; set; }
+
+    }
+}

--- a/src/OnePlusBot/Data/Models/FAQCommandChannel.cs
+++ b/src/OnePlusBot/Data/Models/FAQCommandChannel.cs
@@ -17,12 +17,12 @@ namespace OnePlusBot.Data.Models
         [Column("command_id")]
         public uint FAQCommandId { get; set; }
 
-        [Column("channel_id")]
-        public uint ChannelId { get; set; }
+        [Column("channel_group_id")]
+        public uint ChannelGroupId { get; set; }
 
 
-        [ForeignKey("ChannelId")]
-        public virtual Channel Channel { get; set; }
+        [ForeignKey("ChannelGroupId")]
+        public virtual ChannelGroup ChannelGroupReference { get; set; }
 
 
         [ForeignKey("FAQCommandId")]
@@ -30,8 +30,10 @@ namespace OnePlusBot.Data.Models
     
         public virtual ICollection<FAQCommandChannelEntry> CommandChannelEntries { get; set; }
 
+        
+
         public string display(){
-            return $"ID: {CommandChannelId}: command: {Command.Name} in {Channel.Name}";
+            return $"ID: {CommandChannelId}: command: {Command.Name} in {ChannelGroupReference.Name}";
         }
     }
 }

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -1,0 +1,42 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("PostTargets")]
+    public class PostTarget
+    {        
+        [Column("name")]
+        [Key]
+        public string Name { get; set; }
+
+        [Column("channel_id")]
+        public ulong ChannelId { get; set; }
+
+
+        [ForeignKey("ChannelId")]
+        public virtual Channel ChannelReference { get; set; }
+
+        public static readonly string OFFTOPIC = "offtopic";
+        public static readonly string JOIN_LOG = "joinlog";
+        public static readonly string BAN_LOG = "banlog";
+        public static readonly string DECAY_LOG = "decaylog";
+        public static readonly string DELETE_LOG = "deletelog";
+        public static readonly string EDIT_LOG = "editog";
+        public static readonly string MODMAIL_LOG = "modmaillog";
+        public static readonly string MODMAIL_NOTIFICATION = "modmailnotification";
+        public static readonly string MUTE_LOG = "mutelog";
+        public static readonly string NEWS = "news";
+        public static readonly string PROFANITY_QUEUE = "profanityqueue";
+        public static readonly string STARBOARD = "starboard";
+        public static readonly string UNBAN_LOG = "unbanlog";
+        public static readonly string SUGGESTIONS = "suggestions";
+        public static readonly string USERNAME_QUEUE = "usernamequeue";
+        public static readonly string WARN_LOG = "warnlog";
+        public static readonly string LEAVE_LOG = "leavelog";
+      
+    }
+}

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -25,7 +25,7 @@ namespace OnePlusBot.Data.Models
         public static readonly string BAN_LOG = "banlog";
         public static readonly string DECAY_LOG = "decaylog";
         public static readonly string DELETE_LOG = "deletelog";
-        public static readonly string EDIT_LOG = "editog";
+        public static readonly string EDIT_LOG = "editlog";
         public static readonly string MODMAIL_LOG = "modmaillog";
         public static readonly string MODMAIL_NOTIFICATION = "modmailnotification";
         public static readonly string MUTE_LOG = "mutelog";

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -37,6 +37,16 @@ namespace OnePlusBot.Data.Models
         public static readonly string USERNAME_QUEUE = "usernamequeue";
         public static readonly string WARN_LOG = "warnlog";
         public static readonly string LEAVE_LOG = "leavelog";
+
+        public static readonly List<string> POST_TARGETS = 
+                              new List<string> { 
+                                OFFTOPIC, JOIN_LOG, BAN_LOG, 
+                                DECAY_LOG, DELETE_LOG, EDIT_LOG, 
+                                MODMAIL_LOG, MODMAIL_NOTIFICATION, 
+                                MUTE_LOG, NEWS, PROFANITY_QUEUE, 
+                                STARBOARD, UNBAN_LOG, SUGGESTIONS, 
+                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG
+                              };
       
     }
 }

--- a/src/OnePlusBot/Data/Models/Role.cs
+++ b/src/OnePlusBot/Data/Models/Role.cs
@@ -7,16 +7,15 @@ namespace OnePlusBot.Data.Models
     [Table("Roles")]
     public class Role
     {
-        [Key]
-        [Column("id")]
-        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
-        [Obsolete("Are you sure you don't want to use RoleID?")]
-        public uint ID { get; set; }
         
         [Column("name")]
         public string Name { get; set; }
         
         [Column("role_id")]
+        [Key]
         public ulong RoleID { get; set; }
+
+        [Column("xp_role")]
+        public bool XPRole {get; set; }
     }
 }

--- a/src/OnePlusBot/Data/Models/User.cs
+++ b/src/OnePlusBot/Data/Models/User.cs
@@ -36,6 +36,9 @@ namespace OnePlusBot.Data.Models
         [Column("current_role_id")]
         public uint? ExperienceRoleId { get; set; }
 
+        [Column("xp_gain_disabled")]
+        public bool XPGainDisabled { get; set; }
+
 
         [ForeignKey("Level")]
         public virtual ExperienceLevel CurrentLevel { get; set; }

--- a/src/OnePlusBot/Data/Models/User.cs
+++ b/src/OnePlusBot/Data/Models/User.cs
@@ -20,5 +20,28 @@ namespace OnePlusBot.Data.Models
 
         [Column("modmail_muted_reminded")]
         public Boolean ModMailMutedReminded { get; set; }
+
+        [Column("xp")]
+        public ulong XP { get; set; }
+
+        [Column("xp_updated")]
+        public DateTime Updated { get; set; }
+
+        [Column("current_level")]
+        public uint Level { get; set; }
+
+        [Column("message_count")]
+        public ulong MessageCount { get; set; }
+
+        [Column("current_role_id")]
+        public uint? ExperienceRoleId { get; set; }
+
+
+        [ForeignKey("Level")]
+        public virtual ExperienceLevel CurrentLevel { get; set; }
+
+        [ForeignKey("ExperienceRoleId")]
+        public virtual ExperienceRole ExperienceRoleReference { get; set; }
+
     }
 }

--- a/src/OnePlusBot/Data/Models/User.cs
+++ b/src/OnePlusBot/Data/Models/User.cs
@@ -10,7 +10,7 @@ namespace OnePlusBot.Data.Models
 
         [Key]
         [Column("id")]
-        public ulong UserId { get; set; }
+        public ulong Id { get; set; }
 
         [Column("modmail_muted")]
         public bool ModMailMuted { get; set; }

--- a/src/OnePlusBot/Data/Models/User.cs
+++ b/src/OnePlusBot/Data/Models/User.cs
@@ -9,7 +9,7 @@ namespace OnePlusBot.Data.Models
     {
 
         [Key]
-        [Column("user_id")]
+        [Column("id")]
         public ulong UserId { get; set; }
 
         [Column("modmail_muted")]

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -74,7 +74,7 @@ namespace OnePlusBot.Helpers
         }
 
         public static Channel GetChannelById(ulong channelId){
-            return Global.FullChannels.Where(chan => chan.ChannelID == channelId).DefaultIfEmpty(null).First();
+            return Global.FullChannels.Where(chan => chan.ChannelID2 == channelId).DefaultIfEmpty(null).First();
         }
 
         public static EmbedBuilder FaqCommandEntryToBuilder(FAQCommandChannelEntry entry) {

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -74,7 +74,7 @@ namespace OnePlusBot.Helpers
         }
 
         public static Channel GetChannelById(ulong channelId){
-            return Global.FullChannels.Where(chan => chan.ChannelID2 == channelId).DefaultIfEmpty(null).First();
+            return Global.FullChannels.Where(chan => chan.ChannelID == channelId).DefaultIfEmpty(null).First();
         }
 
         public static EmbedBuilder FaqCommandEntryToBuilder(FAQCommandChannelEntry entry) {

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -1,4 +1,3 @@
-using System.Collections;
 using System;
 using System.Threading.Tasks;
 using Discord.Commands;
@@ -619,8 +618,8 @@ namespace OnePlusBot.Modules
         }
 
         [
-            Command("updateLevels", RunMode = RunMode.Async),
-            Summary("Re-evaluates the experience, levels and assigns the roles to the users"),
+            Command("updateLevels"),
+            Summary("Re-evaluates the experience, levels and assigns the roles to the users (takes a long time, use with care)"),
             RequireRole("staff")
         ]
         public async Task<RuntimeResult> UpdateLevels()
@@ -685,6 +684,43 @@ namespace OnePlusBot.Modules
         }
 
         [
+            Command("setXPDisabled"),
+            Summary("Enables/disables the xp gain in a certain channel group"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> ToggleExperienceGainInChannelGroup([Remainder] string parameters){
+            var parts = parameters.Split(' ');
+            if(parts.Length < 2)
+            {
+                return CustomResult.FromError("setXPDisabled <name> <true/false>");
+            }
+            var name = parts[0];
+            var newValue = parts[1];
+            new ChannelManager().setExpDisabledTo(name, newValue == "true");
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("setGroupDisabled"),
+            Summary("Enables/disables the profanity/invitecheck/xpgain flags for a group"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> ToggleGroupDisabled([Remainder] string parameters){
+            var parts = parameters.Split(' ');
+            if(parts.Length < 2)
+            {
+                return CustomResult.FromError("setGroupDisabled <name> <true/false>");
+            }
+            var name = parts[0];
+            var newValue = parts[1];
+            new ChannelManager().setGroupDisabledTo(name, newValue == "true");
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+
+        [
             Command("setPostTarget"),
             Summary("Sets the target of a certain post"),
             RequireRole("staff")
@@ -699,6 +735,17 @@ namespace OnePlusBot.Modules
             var name = parts[0];
             new ChannelManager().setPostTarget(name, Context.Message);
             await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("listChannelGroups", RunMode=RunMode.Async),
+            Summary("Prints all the channel groups of the server"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> ListChannelGroups()
+        {
+            await new ChannelManager().ListChannelGroups(Context.Channel);
             return CustomResult.FromSuccess();
         }
     }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -657,6 +657,18 @@ namespace OnePlusBot.Modules
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }
+
+        [
+            Command("disableXpGain"),
+            Summary("Enables/disables xp gain for a user"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> SetExpGainEnabled(IGuildUser user, bool newValue)
+        {
+             new ExpManager().SetXPDisabledTo(user, newValue);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
         
     }
 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -620,7 +620,7 @@ namespace OnePlusBot.Modules
         [
             Command("updateLevels", RunMode=RunMode.Async),
             Summary("Re-evaluates the experience, levels and assigns the roles to the users (takes a long time, use with care)"),
-            RequireRole("staff")
+            RequireRole(new string[]{"admin", "founder"})
         ]
         public async Task<RuntimeResult> UpdateLevels([Optional] IGuildUser user)
         {
@@ -641,7 +641,7 @@ namespace OnePlusBot.Modules
         [
             Command("roleLevel"),
             Summary("Sets the level at which a role is given. If no parameters, shows the current role configuration"),
-            RequireRole("staff")
+            RequireRole(new string[]{"admin", "founder"})
         ]
         public async Task<RuntimeResult> SetRoleToLevel([Optional] uint level, [Optional] ulong roleId)
         {
@@ -661,7 +661,7 @@ namespace OnePlusBot.Modules
         [
             Command("disableXpGain"),
             Summary("Enables/disables xp gain for a user"),
-            RequireRole("staff")
+            RequireRole(new string[]{"admin", "founder"})
         ]
         public async Task<RuntimeResult> SetExpGainEnabled(IGuildUser user, bool newValue)
         {

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -14,7 +14,7 @@ namespace OnePlusBot.Modules
     {
 
         [
-            Command("chreateChannelGroup"),
+            Command("createChannelGroup"),
             Summary("Creates a channel group to be used in other areas"),
             RequireRole("staff"),
             Alias("createChGrp")
@@ -65,7 +65,7 @@ namespace OnePlusBot.Modules
         [
             Command("disableXP"),
             Summary("Enables/disables the xp gain in a certain channel group"),
-            RequireRole("staff")
+            RequireRole(new string[]{"admin", "founder"})
         ]
         public async Task<RuntimeResult> ToggleExperienceGainInChannelGroup(string groupName, bool newValue)
         {
@@ -77,7 +77,7 @@ namespace OnePlusBot.Modules
         [
             Command("disableChannelGroup"),
             Summary("Enables/disables the profanity/invitecheck/xpgain flags for a group"),
-            RequireRole("staff"),
+            RequireRole(new string[]{"admin", "founder"}),
             Alias("disableChGrp")
         ]
         public async Task<RuntimeResult> ToggleGroupDisabled(string groupName, bool newValue){

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -68,9 +68,9 @@ namespace OnePlusBot.Modules
             RequireRole(new string[]{"admin", "founder"}),
             Alias("chGrpAtt")
         ]
-        public async Task<RuntimeResult> ToggleExperienceGainInChannelGroup(string groupName, bool xpGain, [Optional] bool? profanityCheck, [Optional] Boolean? inviteCheck)
+        public async Task<RuntimeResult> ToggleChannelGroupAttributes(string groupName, bool xpGain, [Optional] bool? profanityCheck, [Optional] Boolean? inviteCheck)
         {
-            new ChannelManager().setExpDisabledTo(groupName, xpGain, inviteCheck, profanityCheck);
+            new ChannelManager().SetChannelGroupAttributes(groupName, xpGain, inviteCheck, profanityCheck);
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }
@@ -149,7 +149,8 @@ namespace OnePlusBot.Modules
             }
             Dictionary<string, bool> bools = new ChannelManager().EvaluateChannelConfiguration(channel);
             var embedBuilder = new EmbedBuilder().WithTitle($"Current configuration for {channel.Name}");
-            foreach(var config in bools.Keys){
+            foreach(var config in bools.Keys)
+            {
                 embedBuilder.AddField(config, bools[config]);
             }
             await Context.Channel.SendMessageAsync(embed: embedBuilder.Build());

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -94,12 +94,33 @@ namespace OnePlusBot.Modules
             RequireRole("staff"),
             Alias("setTarget")
         ]
-        public async Task<RuntimeResult> SetPostTarget(string channelName, ISocketMessageChannel channel)
+        public async Task<RuntimeResult> SetPostTarget([Optional] string channelName, [Optional] ISocketMessageChannel channel)
         {
-            new ChannelManager().setPostTarget(channelName, channel);
+            if(channelName == null || channel == null)
+            {
+              await new ChannelManager().PostExistingPostTargets(Context.Channel);
+            }
+            else
+            {
+              new ChannelManager().SetPostTarget(channelName, channel);
+            }
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }
+
+        [
+            Command("renameChannelGroup"),
+            Summary("Sets the target of a certain post"),
+            RequireRole("staff"),
+            Alias("rnChGrp")
+        ]
+        public async Task<RuntimeResult> RenameChannelGroup(string oldName, string newName)
+        {
+            new ChannelManager().RenameChannelGroup(oldName, newName);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
 
         [
             Command("listChannelGroups", RunMode=RunMode.Async),

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -1,0 +1,151 @@
+using System.Collections.Generic;
+using System;
+using System.Threading.Tasks;
+using Discord.Commands;
+using OnePlusBot.Base;
+using System.Linq;
+using Discord;
+using Discord.WebSocket;
+using System.Runtime.InteropServices;
+
+namespace OnePlusBot.Modules
+{
+    public class Channels : ModuleBase<SocketCommandContext>
+    {
+
+        [
+            Command("chreateChannelGroup"),
+            Summary("Creates a channel group to be used in other areas"),
+            RequireRole("staff"),
+            Alias("createChGrp")
+        ]
+        public async Task<RuntimeResult> CreateChannelGroup(string groupName)
+        {
+            new ChannelManager().createChannelGroup(groupName);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("addGroupChannels"),
+            Summary("Adds the mentioned channels to the given channel group"),
+            RequireRole("staff"),
+            Alias("addGrpCh")
+        ]
+        public async Task<RuntimeResult> AddToChannelGroup(string groupName, [Remainder] string text)
+        {
+            var parts = text.Split(' ');
+            if(parts.Length < 1)
+            {
+                return CustomResult.FromError("syntax <name> <mentioned channels to be added>");
+            }
+            new ChannelManager().addChannelsToChannelGroup(groupName, Context.Message);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("removeGroupChannels"),
+            Summary("Remoes the mentioned channels from the given channel group"),
+            RequireRole("staff"),
+            Alias("rmGrpCh")
+        ]
+        public async Task<RuntimeResult> RemoveFromChannelGroup(string groupName, [Remainder] string text)
+        {
+            var parts = text.Split(' ');
+            if(parts.Length < 1)
+            {
+                return CustomResult.FromError("syntax <name> <mentioned channels to be added>");
+            }
+            new ChannelManager().removeChannelsFromGroup(groupName, Context.Message);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("disableXP"),
+            Summary("Enables/disables the xp gain in a certain channel group"),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> ToggleExperienceGainInChannelGroup(string groupName, bool newValue)
+        {
+            new ChannelManager().setExpDisabledTo(groupName, newValue);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("disableChannelGroup"),
+            Summary("Enables/disables the profanity/invitecheck/xpgain flags for a group"),
+            RequireRole("staff"),
+            Alias("disableChGrp")
+        ]
+        public async Task<RuntimeResult> ToggleGroupDisabled(string groupName, bool newValue){
+          
+            new ChannelManager().setGroupDisabledTo(groupName, newValue);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+
+        [
+            Command("setPostTarget"),
+            Summary("Sets the target of a certain post"),
+            RequireRole("staff"),
+            Alias("setTarget")
+        ]
+        public async Task<RuntimeResult> SetPostTarget(string channelName, ISocketMessageChannel channel)
+        {
+            new ChannelManager().setPostTarget(channelName, channel);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("listChannelGroups", RunMode=RunMode.Async),
+            Summary("Prints all the channel groups of the server"),
+            RequireRole("staff"),
+            Alias("listChGrp")
+        ]
+        public async Task<RuntimeResult> ListChannelGroups()
+        {
+            await new ChannelManager().ListChannelGroups(Context.Channel);
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("showChannelConfig"),
+            Summary("Show the configuration (disableXP/invitecheck/profanity) of the given or current channel"),
+            RequireRole("staff"),
+            Alias("shChCfg")
+        ]
+        public async Task<RuntimeResult> ShowChannelConfig([Optional] ISocketMessageChannel channel)
+        {
+            if(channel == null)
+            {
+                channel = Context.Channel;
+            }
+            Dictionary<string, bool> bools = new ChannelManager().EvaluateChannelConfiguration(channel);
+            var embedBuilder = new EmbedBuilder().WithTitle($"Current configuration for {channel.Name}");
+            foreach(var config in bools.Keys){
+                embedBuilder.AddField(config, bools[config]);
+            }
+            await Context.Channel.SendMessageAsync(embed: embedBuilder.Build());
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("removeChannelGroup"),
+            Summary("Deletes a channel group (will fail if the group is used anywhere)"),
+            RequireRole("staff"),
+            Alias("rmChGrp")
+        ]
+        public async Task<RuntimeResult> RemoveChannelGroup(string name)
+        {
+            new ChannelManager().RemoveChannelGroup(name);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+    }
+}

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -46,7 +46,7 @@ namespace OnePlusBot.Modules
 
         [
             Command("removeGroupChannels"),
-            Summary("Remoes the mentioned channels from the given channel group"),
+            Summary("Removes the mentioned channels from the given channel group"),
             RequireRole("staff"),
             Alias("rmGrpCh")
         ]
@@ -63,13 +63,14 @@ namespace OnePlusBot.Modules
         }
 
         [
-            Command("disableXP"),
-            Summary("Enables/disables the xp gain in a certain channel group"),
-            RequireRole(new string[]{"admin", "founder"})
+            Command("channelGroupAttributes"),
+            Summary("Enables/disables the attribues in a certain channel group"),
+            RequireRole(new string[]{"admin", "founder"}),
+            Alias("chGrpAtt")
         ]
-        public async Task<RuntimeResult> ToggleExperienceGainInChannelGroup(string groupName, bool newValue)
+        public async Task<RuntimeResult> ToggleExperienceGainInChannelGroup(string groupName, bool xpGain, [Optional] bool? profanityCheck, [Optional] Boolean? inviteCheck)
         {
-            new ChannelManager().setExpDisabledTo(groupName, newValue);
+            new ChannelManager().setExpDisabledTo(groupName, xpGain, inviteCheck, profanityCheck);
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -27,7 +27,7 @@ namespace OnePlusBot.Modules
         public async Task ConfigureFAQ()
         {
             var guild = Global.Bot.GetGuild(Global.ServerID);
-            var configurationStep = new ConfigurationStep("What do you want to do? (➕ add command, ➖ remove command in channel, ☠ delete command)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var configurationStep = new ConfigurationStep("What do you want to do? (➕ add command, ➖ remove command in channel group, ☠ delete command)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
             configurationStep.additionalPosts.Add("To exit react with 🆘 or type exit, depending on the type of step you are in");
             var addStep = new ConfigurationStep("What kind of post do you want to add? (💌 embed, 📖 textpost, ✅ nothing further)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
 

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -32,7 +32,7 @@ namespace OnePlusBot.Modules
             var addStep = new ConfigurationStep("What kind of post do you want to add? (💌 embed, 📖 textpost, ✅ nothing further)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
 
             var aliasesStep = new ConfigurationStep("Please write the aliases you want for this command (comma separated), type 'none' for none", Interactive, Context, ConfigurationStep.StepType.Text, addStep);
-            var channelStep = new ConfigurationStep("In which channel grops should the command be active in?", Interactive, Context, ConfigurationStep.StepType.Text, aliasesStep);
+            var channelStep = new ConfigurationStep("In which channel groups should the command be active in?", Interactive, Context, ConfigurationStep.StepType.Text, aliasesStep);
 
             var commandStep = new ConfigurationStep("What should the name of the command be?", Interactive, Context, ConfigurationStep.StepType.Text, channelStep);
             var textStep = new ConfigurationStep("Please post what the text of the text post should be", Interactive, Context, ConfigurationStep.StepType.Text, addStep);

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -165,7 +165,8 @@ namespace OnePlusBot.Modules
 
             channelStep.beforeTextPosted = async (ConfigurationStep step) => {
                 var embeds = new ChannelManager().GetChannelListEmbed();
-                foreach(var embed in embeds){
+                foreach(var embed in embeds)
+                {
                     var postedMessage = await Context.Channel.SendMessageAsync(embed: embed);
                     channelStep.MessagesToRemoveOnNextProgression.Add(postedMessage);
                     await Task.Delay(100);

--- a/src/OnePlusBot/Modules/Fun.cs
+++ b/src/OnePlusBot/Modules/Fun.cs
@@ -14,7 +14,7 @@ using System.Net.Http;
 using System.IO;
 using OnePlusBot.Data;
 using Microsoft.EntityFrameworkCore;
-
+using OnePlusBot.Data.Models;
 
 namespace OnePlusBot.Modules
 {
@@ -250,7 +250,7 @@ namespace OnePlusBot.Modules
 
         private String BuildStringForMessage(Data.Models.StarboardMessage[] values, List<String> badges)
         {
-            var starBoardChannelId = Global.Channels["starboard"];
+            var starBoardChannelId = Global.PostTargets[PostTarget.STARBOARD];
             var stringBuilder = new StringBuilder();
             for(var index = 0; index < badges.Count(); index++)
             {

--- a/src/OnePlusBot/Modules/Owner.cs
+++ b/src/OnePlusBot/Modules/Owner.cs
@@ -116,7 +116,7 @@ namespace OnePlusBot.Modules
             {
                 foreach (var channel in guild.TextChannels)
                 {
-                    if (db.Channels.Any(x => x.ChannelID2 == channel.Id))
+                    if (db.Channels.Any(x => x.ChannelID == channel.Id))
                         continue;
 
                     var newName = await Ask(
@@ -130,10 +130,8 @@ namespace OnePlusBot.Modules
                     db.Channels.Add(new Channel
                     {
                         Name = newName,
-                        ChannelID2 = channel.Id,
-                        ChannelType = ChannelType.Text,
-                        ProfanityCheckExempt = false,
-                        InviteCheckExempt = false
+                        ChannelID = channel.Id,
+                        ChannelType = ChannelType.Text
                     });
 
                     Console.WriteLine($"[DB] [Update] Added channel {channel.Name} with Name {newName} and ID {channel.Id}");
@@ -145,12 +143,12 @@ namespace OnePlusBot.Modules
                 {
                     foreach (var channel in textChannels)
                     {
-                        if (guild.Channels.Any(x => x.Id == channel.ChannelID2))
+                        if (guild.Channels.Any(x => x.Id == channel.ChannelID))
                             continue;
 
                         db.Channels.Remove(channel);
 
-                        Console.WriteLine($"[DB] [Update] Removed channel {channel.Name} with ID {channel.ChannelID2}");
+                        Console.WriteLine($"[DB] [Update] Removed channel {channel.Name} with ID {channel.ChannelID}");
                         removals--;
                     }
                 }

--- a/src/OnePlusBot/Modules/Owner.cs
+++ b/src/OnePlusBot/Modules/Owner.cs
@@ -172,7 +172,8 @@ namespace OnePlusBot.Modules
                     db.Roles.Add(new Role
                     {
                         Name = newName,
-                        RoleID = role.Id
+                        RoleID = role.Id,
+                        XPRole = false
                     });
 
                     Console.WriteLine($"[DB] [Update] Added role {role.Name} with Name {newName} and ID {role.Id}");

--- a/src/OnePlusBot/Modules/Owner.cs
+++ b/src/OnePlusBot/Modules/Owner.cs
@@ -116,7 +116,7 @@ namespace OnePlusBot.Modules
             {
                 foreach (var channel in guild.TextChannels)
                 {
-                    if (db.Channels.Any(x => x.ChannelID == channel.Id))
+                    if (db.Channels.Any(x => x.ChannelID2 == channel.Id))
                         continue;
 
                     var newName = await Ask(
@@ -130,7 +130,7 @@ namespace OnePlusBot.Modules
                     db.Channels.Add(new Channel
                     {
                         Name = newName,
-                        ChannelID = channel.Id,
+                        ChannelID2 = channel.Id,
                         ChannelType = ChannelType.Text,
                         ProfanityCheckExempt = false,
                         InviteCheckExempt = false
@@ -145,12 +145,12 @@ namespace OnePlusBot.Modules
                 {
                     foreach (var channel in textChannels)
                     {
-                        if (guild.Channels.Any(x => x.Id == channel.ChannelID))
+                        if (guild.Channels.Any(x => x.Id == channel.ChannelID2))
                             continue;
 
                         db.Channels.Remove(channel);
 
-                        Console.WriteLine($"[DB] [Update] Removed channel {channel.Name} with ID {channel.ChannelID}");
+                        Console.WriteLine($"[DB] [Update] Removed channel {channel.Name} with ID {channel.ChannelID2}");
                         removals--;
                     }
                 }

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -54,7 +54,6 @@ namespace OnePlusBot.Modules
                     await ReplyAsync("No module could be found with that name."); 
                     return;
                 }
-
                 output.Title = mod.Name;
                 output.Description = $"{mod.Summary}\n" +
                     (!string.IsNullOrEmpty(mod.Remarks) ? $"({mod.Remarks})\n" : "") +
@@ -90,11 +89,32 @@ namespace OnePlusBot.Modules
 
         public void AddCommand(CommandInfo command, ref EmbedBuilder builder)
         {
+           StringBuilder preconditions = new StringBuilder("");
+            foreach(var pre in command.Preconditions){
+              if(pre is RequireRole){
+                RequireRole casted = pre as RequireRole;
+                preconditions.Append("Required roles: ");
+                if(casted.AllowedRoles.Length > 1)
+                {
+                  string roleConcatenation = casted.mode == ConcatenationMode.AND ? " AND " : " OR ";
+                  preconditions.Append(string.Join(roleConcatenation, casted.AllowedRoles));
+                }
+                else
+                {
+                  preconditions.Append(casted.AllowedRoles[0]);
+                }
+                
+              } 
+            }
+            if(preconditions.ToString() != string.Empty){
+              preconditions.Append("\n");
+            }
             builder.AddField(f =>
             {
                 f.Name = $"**{command.Name}**";
                 f.Value = $"{command.Summary}\n" +
                 (!string.IsNullOrEmpty(command.Remarks) ? $"({command.Remarks})\n" : "") +
+                preconditions.ToString() +
                 (command.Aliases.Any() ? $"**Aliases:** {string.Join(", ", command.Aliases.Select(x => $"`{x}`"))}\n" : "") +
                 $"**Usage:** `{GetPrefix(command)} {GetAliases(command)}`";
             });

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -209,17 +209,18 @@ namespace OnePlusBot.Modules
             if(commandsAvailable.Count() == 0){
                 await Context.Channel.SendMessageAsync("No entry available.");
             } else {
-                var stringBuilder = new StringBuilder();
-                stringBuilder.Append("Available entries in this channel " + Environment.NewLine);
+               var stringBuilder = new StringBuilder(" ");
                 for(var index = 0; index < commandsAvailable.Count; index++)
                 {
                     var command = commandsAvailable[index];
-                    stringBuilder.Append($"{command.Command.Name}");
+                    stringBuilder.Append($"`{command.Command.Name}`");
                     if(index < commandsAvailable.Count -1 ){
                         stringBuilder.Append(", ");
                     }
                 }
-                await Context.Channel.SendMessageAsync(stringBuilder.ToString());
+                var embedBuilder = new EmbedBuilder().WithTitle("Available entries in this channel").WithDescription(stringBuilder.ToString());
+                
+                await Context.Channel.SendMessageAsync(embed: embedBuilder.Build());
             }
            
         }

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -160,7 +160,7 @@ namespace OnePlusBot.Modules
                 var matchingCommand = appropriateCommand.First();
                 if(matchingCommand.CommandChannels != null) 
                 {
-                    var commandChannels = matchingCommand.CommandChannels.Where(cha => cha.Channel.ChannelID == contextChannel.Id);
+                    var commandChannels = matchingCommand.CommandChannels.Where(cha => cha.ChannelGroupReference.Channels.Where(grp => grp.ChannelId == contextChannel.Id) != null);
                     if(commandChannels.Any())
                     {
                         var entries = commandChannels.First().CommandChannelEntries.OrderBy(entry => entry.Position);
@@ -201,7 +201,11 @@ namespace OnePlusBot.Modules
             }
         }
          public async Task PrintAvailableCommands(ISocketMessageChannel contextChannel){
-            var commandsAvailable = Global.FAQCommandChannels.Where(ch => ch.Channel.ChannelID == contextChannel.Id).ToList();
+            var commandsAvailable = Global.FAQCommandChannels.
+            Where(ch => ch.ChannelGroupReference.Channels.
+                Where(grp => grp.ChannelId == contextChannel.Id).
+                FirstOrDefault() != null)
+            .ToList();
             if(commandsAvailable.Count() == 0){
                 await Context.Channel.SendMessageAsync("No entry available.");
             } else {

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -93,7 +93,7 @@ namespace OnePlusBot.Modules
             foreach(var pre in command.Preconditions){
               if(pre is RequireRole){
                 RequireRole casted = pre as RequireRole;
-                preconditions.Append("Required roles: ");
+                preconditions.Append("Required role: ");
                 if(casted.AllowedRoles.Length > 1)
                 {
                   string roleConcatenation = casted.mode == ConcatenationMode.AND ? " AND " : " OR ";
@@ -183,25 +183,32 @@ namespace OnePlusBot.Modules
                     var commandChannels = matchingCommand.CommandChannels.Where(cha => cha.ChannelGroupReference.Channels.Where(grp => grp.ChannelId == contextChannel.Id) != null);
                     if(commandChannels.Any())
                     {
-                        var entries = commandChannels.First().CommandChannelEntries.OrderBy(entry => entry.Position);
-                        if(entries.Any())
+                        if(commandChannels.Count() > 1)
                         {
-                            foreach(var entry in entries)
-                            {
-                                if(!entry.IsEmbed)
-                                {
-                                    await Context.Channel.SendMessageAsync(entry.Text);
-                                }
-                                else 
-                                {
-                                    var embed = Extensions.FaqCommandEntryToBuilder(entry);
-                                    await Context.Channel.SendMessageAsync(embed: embed.Build());
-                                }
-                            }
-                        } 
-                        else
-                        {
-                            await Context.Channel.SendMessageAsync($"Channel has no posts configured for command {appropriateCommand.First().Name}.");
+                          await Context.Channel.SendMessageAsync("Warning command have different responses for this channel");
+                        }
+                        foreach(var commandChannel in commandChannels){
+                          var entries = commandChannels.First().CommandChannelEntries.OrderBy(entry => entry.Position);
+                          if(entries.Any())
+                          {
+                              foreach(var entry in entries)
+                              {
+                                  if(!entry.IsEmbed)
+                                  {
+                                      await Context.Channel.SendMessageAsync(entry.Text);
+                                  }
+                                  else 
+                                  {
+                                      var embed = Extensions.FaqCommandEntryToBuilder(entry);
+                                      await Context.Channel.SendMessageAsync(embed: embed.Build());
+                                  }
+                                  await Task.Delay(200);
+                              }
+                          } 
+                          else
+                          {
+                              await Context.Channel.SendMessageAsync($"Channel has no posts configured for command {appropriateCommand.First().Name}.");
+                          }
                         }
                     }
                     else

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -91,7 +91,8 @@ namespace OnePlusBot.Modules
         {
            StringBuilder preconditions = new StringBuilder("");
             foreach(var pre in command.Preconditions){
-              if(pre is RequireRole){
+              if(pre is RequireRole)
+              {
                 RequireRole casted = pre as RequireRole;
                 preconditions.Append("Required role: ");
                 if(casted.AllowedRoles.Length > 1)
@@ -106,7 +107,8 @@ namespace OnePlusBot.Modules
                 
               } 
             }
-            if(preconditions.ToString() != string.Empty){
+            if(preconditions.ToString() != string.Empty)
+            {
               preconditions.Append("\n");
             }
             builder.AddField(f =>

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -403,7 +403,7 @@ namespace OnePlusBot.Modules
             }
             var embedBuilder = new EmbedBuilder();
             using(var db = new Database()){
-                var userInDb = db.Users.Where(us => us.UserId == userToUse.Id).FirstOrDefault();
+                var userInDb = db.Users.Where(us => us.Id == userToUse.Id).FirstOrDefault();
                 if(userInDb != null){
                     var rank = db.Users.OrderByDescending(us => us.XP).ToList().IndexOf(userInDb) + 1;
                     var nextLevel = db.ExperienceLevels.Where(lv => lv.Level == userInDb.Level + 1).FirstOrDefault();
@@ -445,8 +445,8 @@ namespace OnePlusBot.Modules
                     description.Append("Rank | Name | Experience | Level | Messages \n");
                     foreach(var user in usersToDisplay){
                         var rank = allUsers.IndexOf(user) + 1;
-                        var userInGuild = Context.Guild.GetUser(user.UserId);
-                        var name = userInGuild != null ? Extensions.FormatUserName(userInGuild) : "User left guild " + user.UserId;
+                        var userInGuild = Context.Guild.GetUser(user.Id);
+                        var name = userInGuild != null ? Extensions.FormatUserName(userInGuild) : "User left guild " + user.Id;
                         description.Append($"[#{rank}] → {name}\n");
                         description.Append($"XP: {user.XP} Level: {user.Level}: Messages: {user.MessageCount} \n");
                     }
@@ -454,10 +454,10 @@ namespace OnePlusBot.Modules
                 }
                
                 description.Append("Your placement: \n");
-                var caller = db.Users.Where(us => us.UserId == Context.Message.Author.Id).FirstOrDefault();
+                var caller = db.Users.Where(us => us.Id == Context.Message.Author.Id).FirstOrDefault();
                 if(caller != null){
                     var callRank = allUsers.IndexOf(caller) + 1;
-                    var userInGuild = Context.Guild.GetUser(caller.UserId);
+                    var userInGuild = Context.Guild.GetUser(caller.Id);
                     description.Append($"[#{callRank}] → {Extensions.FormatUserName(userInGuild)} XP: {caller.XP} messages: {caller.MessageCount}");
                 }
                 embedBuilder = embedBuilder.WithDescription(description.ToString());

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -1,3 +1,4 @@
+using System.Security.Cryptography;
 using System.Text;
 using System.Threading.Tasks;
 using Discord;
@@ -137,7 +138,7 @@ namespace OnePlusBot.Modules
         ]
         public async Task SuggestAsync([Remainder] string suggestion)
         {
-            var suggestionsChannel = Context.Guild.GetTextChannel(Global.Channels["suggestions"]);
+            var suggestionsChannel = Context.Guild.GetTextChannel(Global.PostTargets[PostTarget.SUGGESTIONS]);
             var user = Context.Message.Author;
 
             if (suggestion.Contains("@everyone") || suggestion.Contains("@here"))
@@ -170,7 +171,7 @@ namespace OnePlusBot.Modules
             
             var needsAttachments = Context.Message.Attachments.Count() > 0;
             
-            var newsChannel = guild.GetTextChannel(Global.Channels["news"]) as SocketNewsChannel;
+            var newsChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.NEWS]) as SocketNewsChannel;
             var newsRole = guild.GetRole(Global.Roles["news"]);
 
             if (news.Contains("@everyone") || news.Contains("@here") || news.Contains("@news")) 
@@ -383,6 +384,82 @@ namespace OnePlusBot.Modules
                     return CustomResult.FromError("Reminder not known or not started by you.");
                 }
             }
+        }
+
+        [
+            Command("rank"),
+            Summary("Shows your experience")
+        ]
+        public async Task<RuntimeResult> ShowLevels([Optional] IGuildUser user)
+        {
+            IUser userToUse = null;
+            if(user != null){
+                userToUse = user;
+            } else {
+                userToUse = Context.Message.Author;
+            }
+            if(userToUse.IsBot){
+                return CustomResult.FromIgnored();
+            }
+            var embedBuilder = new EmbedBuilder();
+            using(var db = new Database()){
+                var userInDb = db.Users.Where(us => us.UserId == userToUse.Id).FirstOrDefault();
+                if(userInDb != null){
+                    var rank = db.Users.OrderByDescending(us => us.XP).ToList().IndexOf(userInDb) + 1;
+                    var nextLevel = db.ExperienceLevels.Where(lv => lv.Level == userInDb.Level + 1).FirstOrDefault();
+                    embedBuilder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(userToUse.GetAvatarUrl()).WithName(userToUse.Username));
+                    embedBuilder.AddField("Current XP", userInDb.XP, true);
+                    embedBuilder.AddField("Current Level", userInDb.Level, true);
+                    if(nextLevel != null){
+                        embedBuilder.AddField("XP to next Level", nextLevel.NeededExperience - userInDb.XP, true);
+                    }
+                    embedBuilder.AddField("Rank", rank, true);
+                }
+            }
+            await Context.Channel.SendMessageAsync(embed: embedBuilder.Build());
+            return CustomResult.FromSuccess();
+        }
+
+         [
+            Command("leaderboard"),
+            Summary("shows the top page of the leaderboard (or a certain page)")
+        ]
+        public async Task<RuntimeResult> ShowLeaderboard([Optional] int page)
+        {
+            var embedBuilder = new EmbedBuilder();
+            using(var db = new Database()){
+                var allUsers = db.Users.OrderByDescending(us => us.XP).ToList();
+                var usersInLeaderboard = db.Users.OrderByDescending(us => us.XP).Skip(page * 10).Take(10).ToList();
+                embedBuilder = embedBuilder.WithTitle("Leaderboard of gained experience");
+                var description = new StringBuilder();
+                if(page * 10 > allUsers.Count()){
+                    description.Append("Page not found. \n");
+                } else {
+                    description.Append("Rank | Name \n");
+                    foreach(var user in usersInLeaderboard){
+                        var rank = allUsers.IndexOf(user) + 1;
+                        var userInGuild = Context.Guild.GetUser(user.UserId);
+                        var name = userInGuild != null ? Extensions.FormatUserName(userInGuild) : "User left guild " + user.UserId;
+                        description.Append($"[#{rank}] → {name}\n");
+                        description.Append($"Experience: {user.XP} Level: {user.Level} \n");
+                    }
+                    description.Append("\n");
+                }
+               
+                description.Append("Your placement: \n");
+                var caller = db.Users.Where(us => us.UserId == Context.Message.Author.Id).FirstOrDefault();
+                if(caller != null){
+                    var callRank = allUsers.IndexOf(caller) + 1;
+                    var userInGuild = Context.Guild.GetUser(caller.UserId);
+                    description.Append($"[#{callRank}] → {Extensions.FormatUserName(userInGuild)} Experience: {caller.XP}");
+                }
+                embedBuilder = embedBuilder.WithDescription(description.ToString());
+                embedBuilder.WithFooter(new EmbedFooterBuilder().WithText("Use leaderboard <page> to view more of the leaderboard"));
+                await Context.Channel.SendMessageAsync(embed: embedBuilder.Build());
+               
+            }
+           
+            return CustomResult.FromSuccess();
         }
 
        /* [Command("timeleft")]

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -388,7 +388,7 @@ namespace OnePlusBot.Modules
 
         [
             Command("rank"),
-            Summary("Shows your experience")
+            Summary("Shows your experience, level, and rank in the server")
         ]
         public async Task<RuntimeResult> ShowLevels([Optional] IGuildUser user)
         {
@@ -447,8 +447,8 @@ namespace OnePlusBot.Modules
                         var rank = allUsers.IndexOf(user) + 1;
                         var userInGuild = Context.Guild.GetUser(user.Id);
                         var name = userInGuild != null ? Extensions.FormatUserName(userInGuild) : "User left guild " + user.Id;
-                        description.Append($"[#{rank}] → {name}\n");
-                        description.Append($"XP: {user.XP} Level: {user.Level}: Messages: {user.MessageCount} \n");
+                        description.Append($"[#{rank}] → **{name}**\n");
+                        description.Append($"XP: {user.XP} Level: {user.Level}: Messages: {user.MessageCount} \n \n");
                     }
                     description.Append("\n");
                 }


### PR DESCRIPTION
This PR adds the ability to track chat activity via experience, levels and roles.

This PR changes the behavior how the bot uses the Channels. Before, the bot was only aware of channels, and used the same object for selecting a target to post something to and to see what the proper channel for an action is and whether or not invite checks/profanity checks are enabled in a specific channel.

Now there are the concepts of post Targets and channel groups additionally. (while still maintaining the old channels for some areas).

A post target is something where the bot actively posts something to. For example, there is a post target for 'starboard', which is basically just a channel id with this name in the database. (In a separate table so we can separate them). The command `setposttarget <name> <channel mention>` exists so you can set this to another channel. For example `setposttarget starboard #general` would cause the starboard to post to general instead. If something like this is configured, a `reloaddb` is necessary. If a parameter is missing, or none is provided `setposttarget` prints the currently available post targets. They have a descriptive name and their purpose should be visible.

A channel group is a logical group within the bot. It does not match to any concept of discord.
A channel group is basically a collection of channels used under one name. A group can have certain configurations (experience gain disabled, profanity check disabled, invite check disabled) and a channel can be in multiple groups. If a channel is in multiple groups and one attribute is allowed in one of them, the attribute is allowed for this channel. A channel group can be disabled as well. When a group is disabled, its attributes (whether or not they are allowing or disallowing) do not count towards this. A channel group can have its channels added/removed and it can be renamed. A channel group can only be removed if there are no channels contained. The name of the group is unique. To see what the configuration for a current channel is use `showchannelconfig` in the channel, or mention another channel as a parameter.

Experience tracking:
When a user is posting a message this is recognized, every minute at the thirty second mark, if the user posted a message within the previous minute, the users experience is incremented by a configured random amount in a range configured in the database. Afterwards it is evaluated whether or not that changes the level of the user, and if it did, it also checks if a new role has to be defined.
The experience needed for a level are predefined and cannot be adapted externally, but the level at which a certain role is given can be changed with the command `rolelevel`, if no parameter is given the current configuration is shown.
Experience can be disabled globally (database only). It can be disabled for a certain channel group and it can be disabled for a certain user.
Users can check their level and experience with the command `rank` and with `leaderboard` they can check the leaderboard, which is the experience and levels of other uses (they still see themselves at the bottom) The leader board is paginated, the parameter is the page the user wants to know about.

**Before this PR is merged, it needs major changes in the db.**
In short, the currently configured faq commands need to be migrated and the channel groups need to be migrated. This can be done after the deployment is done in runtime (by just reconfiguring the responses, this should be good enough)

This PR also includes a fix regarding modqueue (only the YES and NO emotes trigger the effect of decididing whether or not something is a profanity).
Additionally there can bow be multiple roles configured per command, which can be concatenated via AND or OR, and if the expression is true, the command is executed.
These roles are now also shown in the help command.
Also a error message is shown again, when the user provided too little parameters for a command.