### PR TITLE
Illegal username checks after join

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -331,6 +331,7 @@ CREATE TABLE `ChannelInGroup` (
  `channel_group_id` int(10) unsigned NOT NULL,
  PRIMARY KEY (`channel_id`,`channel_group_id`),
  KEY `fk_group_id` (`channel_group_id`),
+ CONSTRAINT `fk_channel_id_ref` FOREIGN KEY (`channel_id`) REFERENCES `Channels` (`channel_id`),
  CONSTRAINT `fk_group_id` FOREIGN KEY (`channel_group_id`) REFERENCES `ChannelGroups` (`id`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 

--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -310,6 +310,7 @@ CREATE TABLE `ThreadMessage` (
 -- Table structure for table `ChannelGroups`
 --
 
+DROP TABLE IF EXISTS `ChannelGroups`;
 CREATE TABLE `ChannelGroups` (
   `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -324,6 +325,7 @@ CREATE TABLE `ChannelGroups` (
 -- Table structure for table `ChannelInGroup`
 --
 
+DROP TABLE IF EXISTS `ChannelInGroup`;
 CREATE TABLE `ChannelInGroup` (
  `channel_id` bigint(20) unsigned NOT NULL,
  `channel_group_id` int(10) unsigned NOT NULL,
@@ -336,11 +338,40 @@ CREATE TABLE `ChannelInGroup` (
 -- Table structure for table `PostTargets`
 --
 
+DROP TABLE IF EXISTS `PostTargets`;
 CREATE TABLE `PostTargets` (
  `channel_id` bigint(20) unsigned NOT NULL,
  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
  PRIMARY KEY (`name`),
  UNIQUE KEY `name` (`name`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+--
+-- Table structure for table `ExperienceRoles`
+--
+
+DROP TABLE IF EXISTS `ExperienceRoles`;
+CREATE TABLE `ExperienceRoles` (
+ `role_id` bigint(20) unsigned NOT NULL,
+ `level` int(10) unsigned NOT NULL,
+ `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ PRIMARY KEY (`id`),
+ KEY `fk_level` (`level`),
+ KEY `fk_role` (`role_id`),
+ CONSTRAINT `fk_level` FOREIGN KEY (`level`) REFERENCES `ExperienceLevels` (`level`),
+ CONSTRAINT `fk_role` FOREIGN KEY (`role_id`) REFERENCES `Roles` (`role_id`)
+) ENGINE=InnoDB AUTO_INCREMENT=41 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `ExperienceRoles`
+--
+
+DROP TABLE IF EXISTS `ExperienceLevels`;
+CREATE TABLE `ExperienceLevels` (
+ `level` int(10) unsigned NOT NULL,
+ `needed_experience` bigint(20) unsigned NOT NULL,
+ PRIMARY KEY (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/sql_scripts/seed_data.sql
+++ b/sql_scripts/seed_data.sql
@@ -5,13 +5,14 @@ INSERT INTO `PersistentData` VALUES
 (4,'starboard_stars',1, ''),
 (5,'level_2_stars',2, ''),
 (6,'level_3_stars',3, ''),
-(7,'decay_days', 90, ''),
-(8, 'modmail_category_id', 0, ''),
-(9, 'user_name_illegal_characters', 0, ''),
-(10, 'xp_disabled', 1, ''),
-(11, 'xp_gain_range_min', 10, ''),
-(12, 'xp_gain_range_max', 25, ''),
-(13, 'illegal_user_name_regex', 0, '');
+(7,'level_4_stars',3, ''),
+(8,'decay_days', 90, ''),
+(9, 'modmail_category_id', 0, ''),
+(10, 'user_name_illegal_characters', 0, ''),
+(11, 'xp_disabled', 1, ''),
+(12, 'xp_gain_range_min', 10, ''),
+(13, 'xp_gain_range_max', 25, ''),
+(14, 'illegal_user_name_regex', 0, '');
 
 INSERT INTO `AuthTokens` VALUES 
 (1,'stable','REPLACE WITH TOKEN'),
@@ -20,7 +21,7 @@ INSERT INTO `AuthTokens` VALUES
 
 INSERT INTO `Channels` (`name`, `channel_id`, `channel_type`) VALUES
 ('setups', 0, 0),
-('referralcodes', 0, 0);
+('referralcodes', 1, 0);
 
 INSERT INTO  `Roles` (`name`, `role_id` ) VALUES
 ('staff', 0);

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -162,16 +162,22 @@ namespace OnePlusBot.Base
             db.SaveChanges();
           }
         }
-
+        /// <summary>
+        /// Sets the target of the post target defined by the name to the given channel in the database. Does not reload the Global object. 
+        /// In case the post target was valid, but not yet defined, this method creates a new one.
+        /// </summary>
+        /// <param name="name">Name of the post target to change</param>
+        /// <param name="channel">The <see cref="Discord.IChannel"/> object the posts of this post target should be posted towards</param>
+        /// <exception cref="OnePlusBot.Base.Errors.NotFoundException">In case the desired post target is not found</exception>
         public void SetPostTarget(string name, IChannel channel)
         {
             using(var db = new Database())
             {
-                var existingTarget = db.PostTargets.Where(pt => pt.Name == name).FirstOrDefault();
+                var existingTarget = db.PostTargets.Where(pt => pt.Name == name);
                 PostTarget newPostTarget;
-                if(existingTarget != null)
+                if(existingTarget.Any())
                 {
-                    newPostTarget = existingTarget;
+                    newPostTarget = existingTarget.First();
                     newPostTarget.ChannelId = channel.Id;
                 }
                 else

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -157,7 +157,7 @@ namespace OnePlusBot.Base
             }
             else 
             {
-                throw new NotFoundException("Channel group not found.");
+              throw new NotFoundException("Channel group not found.");
             }
             db.SaveChanges();
           }
@@ -176,10 +176,14 @@ namespace OnePlusBot.Base
                 }
                 else
                 {
-                    newPostTarget = new PostTarget();
-                    newPostTarget.Name = name;
-                    newPostTarget.ChannelId = channel.Id;
-                    db.PostTargets.Add(newPostTarget);
+                  if(!PostTarget.POST_TARGETS.Where(t => t == name).Any())
+                  {
+                    throw new NotFoundException("Post target does not exist.");
+                  }
+                  newPostTarget = new PostTarget();
+                  newPostTarget.Name = name;
+                  newPostTarget.ChannelId = channel.Id;
+                  db.PostTargets.Add(newPostTarget);
                 }
                 db.SaveChanges();
             }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -51,7 +51,8 @@ namespace OnePlusBot.Base
             await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
         }
 
-        private async Task OnGlobalUserUpdated(SocketUser before, SocketUser after){
+        private async Task OnGlobalUserUpdated(SocketUser before, SocketUser after)
+        {
           // fires when the username changed
           bool userNameChanged = before.Username != after.Username;
           SocketGuild guild = Global.Bot.GetGuild(Global.ServerID);
@@ -68,7 +69,8 @@ namespace OnePlusBot.Base
               await NotifyAboutIllegalUserName(embedTitle, beforeText, afterText, after, guild);
             }
           }
-          if(userNameChanged && !nicknameSet){
+          if(userNameChanged && !nicknameSet)
+          {
             await HandleNameChangesForModmail(after, guild, "User Changed username", beforeText, afterText);
           }
         }
@@ -127,7 +129,8 @@ namespace OnePlusBot.Base
           }
         }
 
-        private async Task NotifyAboutIllegalUserName(string embedTitle, string beforeText, string afterText, IUser user, SocketGuild guild){
+        private async Task NotifyAboutIllegalUserName(string embedTitle, string beforeText, string afterText, IUser user, SocketGuild guild)
+        {
           EmbedBuilder builder = new EmbedBuilder();
           builder.Title = embedTitle;
           builder.AddField("Before", beforeText);
@@ -169,7 +172,8 @@ namespace OnePlusBot.Base
             await joinlog.SendMessageAsync(Extensions.FormatMentionDetailed(socketGuildUser) + " joined the guild");
         }
 
-        private bool IllegalUserName(string userName){
+        private bool IllegalUserName(string userName)
+        {
           return Global.IllegalUserNameRegex.Match(userName.ToLower()[0] + "").Success;
         }
 

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -51,6 +51,14 @@ namespace OnePlusBot.Base
             await _commands.AddModulesAsync(Assembly.GetEntryAssembly(), _services);
         }
 
+        /// <summary>
+        /// Fires when the global user is updated and checks if the new user is in accordance with the defined username regex.
+        /// In case it violates this regex and no nickname is set, this method calls another method responsible for notifying the moderators.
+        /// Additionally, calls the method responsible for notifying currently active modmail threads.
+        /// </summary>
+        /// <param name="before">The <see cref="Discord.WebSocket.SocketUser"/> object containing the user before the update</param>
+        /// <param name="after">The <see cref="Discord.WebSocket.SocketUser"/> object containing the user after the update</param>
+        /// <returns>Task</returns>
         private async Task OnGlobalUserUpdated(SocketUser before, SocketUser after)
         {
           // fires when the username changed
@@ -75,6 +83,16 @@ namespace OnePlusBot.Base
           }
         }
 
+        /// <summary>
+        /// In case there is a curently open modmail thread for the given user, 
+        /// this method posts an embed with the given title and values for two fields called 'Before' and 'After'
+        /// </summary>
+        /// <param name="user">The <see cref="Discord.IUser" /> object to check if there exists a modmail thread.</param>
+        /// <param name="guild">The <see cref"Discord.WebSocket.SocketGuild"/> object for which the check should be executed for. </param>
+        /// <param name="embedTitle">Title of the embed</param>
+        /// <param name="beforeText">Text for the field 'Before'</param>
+        /// <param name="afterText">Text for the field 'After'</param>
+        /// <returns>Task</returns>
         private async Task HandleNameChangesForModmail(IUser user, SocketGuild guild, string embedTitle, string beforeText, string afterText)
         {
           using(var db = new Database())
@@ -83,19 +101,40 @@ namespace OnePlusBot.Base
             var modmailThreadExists = modmailThread.Any();
             if(modmailThreadExists)
             {
-              EmbedBuilder builder = new EmbedBuilder();
-              builder.Title = embedTitle;
-              builder.AddField("Before", beforeText);
-              builder.AddField("After", afterText);
-              builder.Color = Color.DarkBlue;
-              builder.Timestamp = DateTime.Now;
-                
-              builder.ThumbnailUrl = user.GetAvatarUrl();
-              await guild.GetTextChannel(modmailThread.First().ChannelId).SendMessageAsync(embed: builder.Build());
+              var embed = GetUserNameNotificationEmbed(embedTitle, beforeText, afterText, user);
+              await guild.GetTextChannel(modmailThread.First().ChannelId).SendMessageAsync(embed: embed);
             }  
           }
         }
 
+        /// <summary>
+        /// Builds the embed posted in case a user changes the username/nickname.
+        /// </summary>
+        /// <param name="embedTitle">Title of the embed</param>
+        /// <param name="beforeText">The text of the field 'Before' for the embed</param>
+        /// <param name="afterText">The text of the field 'After' for the embed</param>
+        /// <param name="user">The <see cref"Discord.IUser"/> object to take the avatar as thumbnail</param>
+        /// <returns>Embed containing build after the given parameters</returns>
+        private Embed GetUserNameNotificationEmbed(string embedTitle, string beforeText, string afterText, IUser user)
+        {
+          EmbedBuilder builder = new EmbedBuilder();
+          builder.Title = embedTitle;
+          builder.AddField("Before", beforeText);
+          builder.AddField("After", afterText);
+          builder.Color = Color.DarkBlue;
+          builder.Timestamp = DateTime.Now;
+            
+          builder.ThumbnailUrl = user.GetAvatarUrl();
+          return builder.Build();
+        }
+
+        /// <summary>
+        /// Fires in case the guild user updates and checks if the new nickname (or username, if user removed the nickname) is in accordance of the rules for usernames.
+        /// If not, calls the method to notify the moderators. Additionally, calls the method responsible for notifying currently active modmail threads.
+        /// </summary>
+        /// <param name="before">The <see cref"Discord.WebSocket.SocketGuildUser"/> object containing the user before the update</param>
+        /// <param name="after">The <see cref"Discord.WebSocket.SocketGuildUser"/> object containing the user after the update</param>
+        /// <returns>Task</returns>
         private async Task OnGuildMemberUpdated(SocketGuildUser before, SocketGuildUser after)
         {
           // fires when the nickname changes
@@ -115,6 +154,7 @@ namespace OnePlusBot.Base
           } 
           else if(nickNameChanged && !nicknameSet)
           {
+            // in case the user reset its nickname to nothing
             if(IllegalUserName(after.Username))
             {
               embedTitle = "User removed nickname, and username is illegal";
@@ -129,20 +169,21 @@ namespace OnePlusBot.Base
           }
         }
 
+        /// <summary>
+        /// Posts a message towards the 'UserNameQueue' post target containing the name before and after the change with the given title.
+        /// The embed has as thumbnail the avatar of the user (none if default) and is posted towards the given guild.
+        /// </summary>
+        /// <param name="embedTitle">Title of the embed</param>
+        /// <param name="beforeText">Text of the embed to be used for the 'Before' field</param>
+        /// <param name="afterText">Text of the embed to be used for the 'After' field</param>
+        /// <param name="user">User with the invalid username, used for the avatar in the embed.</param>
+        /// <param name="guild">The <see cref"Discord.WebSocket.SocketGuild"/> guild where this is posted towards in the 'UserNameQueue' post target</param>
+        /// <returns></returns>
         private async Task NotifyAboutIllegalUserName(string embedTitle, string beforeText, string afterText, IUser user, SocketGuild guild)
         {
-          EmbedBuilder builder = new EmbedBuilder();
-          builder.Title = embedTitle;
-          builder.AddField("Before", beforeText);
-          builder.AddField("After", afterText);
-          builder.Color = Color.DarkBlue;
-        
-          builder.Timestamp = DateTime.Now;
-          
-          builder.ThumbnailUrl = user.GetAvatarUrl();
-
+          var embed = GetUserNameNotificationEmbed(embedTitle, beforeText, afterText, user);
           var userlog = guild.GetTextChannel(Global.PostTargets[PostTarget.USERNAME_QUEUE]);
-          await userlog.SendMessageAsync(embed: builder.Build());
+          await userlog.SendMessageAsync(embed: embed);
         }
 
         private async Task OnUserLeft(SocketGuildUser socketGuildUser)
@@ -151,6 +192,12 @@ namespace OnePlusBot.Base
             await leaveLog.SendMessageAsync(Extensions.FormatMentionDetailed(socketGuildUser) + " left the guild");
         }
 
+        /// <summary>
+        /// Fires when a user joins the guild. Checks if the username of the user is in accordance with the given username regex.
+        /// If this is not the case, calls the method to notify the moderators.
+        /// </summary>
+        /// <param name="socketGuildUser">The <see cref"Discord.WebSocket.SocketGuildUser"/> object containing the user joining the guild.</param>
+        /// <returns>Task</returns>
         private async Task OnuserUserJoined(SocketGuildUser socketGuildUser)
         {
           
@@ -172,6 +219,11 @@ namespace OnePlusBot.Base
             await joinlog.SendMessageAsync(Extensions.FormatMentionDetailed(socketGuildUser) + " joined the guild");
         }
 
+        /// <summary>
+        /// Checks if the given string is in accordance with the given username regex (only the first character is checked)
+        /// </summary>
+        /// <param name="userName">The username as string which is checked</param>
+        /// <returns>True in case the string matches with the username regex.</returns>
         private bool IllegalUserName(string userName)
         {
           return Global.IllegalUserNameRegex.Match(userName.ToLower()[0] + "").Success;

--- a/src/OnePlusBot/Base/ModMailEmbedHandler.cs
+++ b/src/OnePlusBot/Base/ModMailEmbedHandler.cs
@@ -77,7 +77,8 @@ namespace OnePlusBot
 
         private static StringBuilder GetClosingHeader(ModMailThread thread, int messageCount, SocketUser user, string note){
             var descriptionBuilder = new StringBuilder();
-            descriptionBuilder.Append($"A modmail thread has been closed with the note '{note}' \n ");
+            string defaultedNote = note ?? "No note";
+            descriptionBuilder.Append($"A modmail thread has been closed with the note '{ defaultedNote }' \n ");
             descriptionBuilder.Append($"There were {messageCount} interactions with the user {Extensions.FormatUserNameDetailed(user)}. \n");
             descriptionBuilder.Append($"It has been opened on {thread.CreateDate:dd.MM.yyyy HH:mm} {TimeZoneInfo.Local}");
             descriptionBuilder.Append($" and lasted {Extensions.FormatTimeSpan(DateTime.Now - thread.CreateDate)}.");

--- a/src/OnePlusBot/Base/ModMailEmbedHandler.cs
+++ b/src/OnePlusBot/Base/ModMailEmbedHandler.cs
@@ -75,6 +75,14 @@ namespace OnePlusBot
             return embed.Build();
         }
 
+        /// <summary>
+        /// Returns the string containing the given parameters formatted as the header used in the 'ModMailLog' embed which is used as the header
+        /// </summary>
+        /// <param name="thread">The <see cref"OnePlusBot.Data.Models.ModMailThread"/> object which is being closed.</param>
+        /// <param name="messageCount">The amount of interactions between the user and the staff</param>
+        /// <param name="user">The <see cref"Discord.WebSocket.SocketUser"/> object for who the thread was created</param>
+        /// <param name="note">An optional note which is displayed as information in the closing header</param>
+        /// <returns>The StringBuilder object containing the formatted information used as closing header.</returns>
         private static StringBuilder GetClosingHeader(ModMailThread thread, int messageCount, SocketUser user, string note){
             var descriptionBuilder = new StringBuilder();
             string defaultedNote = note ?? "No note";

--- a/src/OnePlusBot/Base/ModMailManager.cs
+++ b/src/OnePlusBot/Base/ModMailManager.cs
@@ -195,6 +195,13 @@ namespace OnePlusBot.Base
         return threadObj;
     }
 
+    /// <summary>
+    /// Logs the messages between staff and user (only interactions) from the given modmail thread towards the given channel with a delay of 500
+    /// </summary>
+    /// <param name="modMailThread">The <see cref"OnePlusBot.Data.Models.ModMailThread"/> object containing the information of the thread</param>
+    /// <param name="messagesToLog">List containing the messages between the moderators and the user which should be logged.</param>
+    /// <param name="targetChannel">The <see cref"Discord.WebSocket.SocketTextChannel"/> object these messages should be logged to</param>
+    /// <returns>Task</returns>
     private async Task LogModMailThreadMessagesToModmailLog(ModMailThread modMailThread, List<ThreadMessage> messagesToLog, SocketTextChannel targetChannel)
     {
         var bot = Global.Bot;
@@ -226,6 +233,13 @@ namespace OnePlusBot.Base
         await modMailLogChannel.SendMessageAsync(embed: closingEmbed);
     }
 
+    /// <summary>
+    /// Retrieves the interactions between the moderators and staff, calls the methods reponsible for logging the interactions and deletes the channel
+    /// </summary>
+    /// <param name="closedThread">The <see cref"OnePlusBot.Data.Models.ModMailThread"/> object of the thread being closed</param>
+    /// <param name="channel">The <see cref"Discord.WebSocket.ISocketMessageChannel"/> object in which the modmail interactions happened</param>
+    /// <param name="note">Optional note used when closing the thread</param>
+    /// <returns>Task containing the number of logged messages.</returns>
     private async Task<int> DeleteChannelAndLogThread(ModMailThread closedThread, ISocketMessageChannel channel, string note){
       var bot = Global.Bot;
       var guild = bot.GetGuild(Global.ServerID);
@@ -243,6 +257,13 @@ namespace OnePlusBot.Base
       return messagesToLog.Count();
     }
 
+    /// <summary>
+    /// Calls the methods for closing the thread in the db and logging the modmail thread. 
+    /// Also sends a message to the user, in case there were interactions 
+    /// </summary>
+    /// <param name="channel">The <see cref"Discord.WebSocket.ISocketMessageChannel"/> object of the channel which is getting closed</param>
+    /// <param name="note">The optional note which is used when closing the thread</param>
+    /// <returns>Task</returns>
     public async Task CloseThread(ISocketMessageChannel channel, string note)
     { 
         var closedThread = CloseThreadInDb(channel);  
@@ -257,6 +278,12 @@ namespace OnePlusBot.Base
         }
     }
 
+    /// <summary>
+    /// Calls the methods for closing the thread in the db and logging the modmail thread. 
+    /// </summary>
+    /// <param name="channel">The <see cref"Discord.WebSocket.ISocketMessageChannel"/> object of the channel which is getting closed</param>
+    /// <param name="note">The optional note which is used when closing the thread</param>
+    /// <returns>Task</returns>
     public async Task CloseThreadSilently(ISocketMessageChannel channel, string note)
     { 
       var closedThread = CloseThreadInDb(channel);  

--- a/src/OnePlusBot/Base/ModMailManager.cs
+++ b/src/OnePlusBot/Base/ModMailManager.cs
@@ -169,7 +169,7 @@ namespace OnePlusBot.Base
         var threadUser = guild.GetUser(userObj.UserId);
         if(threadUser != null)
         {
-            var replyEmbed = ModMailEmbedHandler.GetModeratorReplyEmbed(clearMessage, "Moderator replied", message, anonymous ? null : moderatorUser);
+            var replyEmbed = ModMailEmbedHandler.GetModeratorReplyEmbed(clearMessage, "Moderator posted", message, anonymous ? null : moderatorUser);
             await AnswerUserAndLogEmbed(threadUser, channel, replyEmbed, message, anonymous);
         }
         else
@@ -195,7 +195,7 @@ namespace OnePlusBot.Base
         return threadObj;
     }
 
-    private async Task LogModMailThreadMessagesToModmailLog(ModMailThread modMailThread, string note, List<ThreadMessage> messagesToLog, SocketTextChannel targetChannel)
+    private async Task LogModMailThreadMessagesToModmailLog(ModMailThread modMailThread, List<ThreadMessage> messagesToLog, SocketTextChannel targetChannel)
     {
         var bot = Global.Bot;
         var guild = bot.GetGuild(Global.ServerID);
@@ -226,27 +226,41 @@ namespace OnePlusBot.Base
         await modMailLogChannel.SendMessageAsync(embed: closingEmbed);
     }
 
-    public async Task CloseThread(SocketMessage message, ISocketMessageChannel channel, SocketUser moderatorUser, string note)
+    private async Task<int> DeleteChannelAndLogThread(ModMailThread closedThread, ISocketMessageChannel channel, string note){
+      var bot = Global.Bot;
+      var guild = bot.GetGuild(Global.ServerID);
+      SocketGuildUser userObj = guild.GetUser(closedThread.UserId);
+      List<ThreadMessage> messagesToLog;
+      using(var db = new Database())
+      {
+          messagesToLog = db.ThreadMessages.Where(ch => ch.ChannelId == closedThread.ChannelId).ToList();
+      }
+      var modMailLogChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_LOG]);
+      await LogClosingHeader(closedThread, messagesToLog.Count(), note, modMailLogChannel, userObj);
+
+      await LogModMailThreadMessagesToModmailLog(closedThread, messagesToLog, modMailLogChannel);
+      await (channel as SocketTextChannel).DeleteAsync();
+      return messagesToLog.Count();
+    }
+
+    public async Task CloseThread(ISocketMessageChannel channel, string note)
     { 
-        var closedthread = CloseThreadInDb(channel);   
+        var closedThread = CloseThreadInDb(channel);  
+        int messagesToLogCount = await DeleteChannelAndLogThread(closedThread, channel, note);
         var bot = Global.Bot;
         var guild = bot.GetGuild(Global.ServerID);
-        SocketGuildUser userObj = guild.GetUser(closedthread.UserId);
-        List<ThreadMessage> messagesToLog;
-        using(var db = new Database())
-        {
-            messagesToLog = db.ThreadMessages.Where(ch => ch.ChannelId == closedthread.ChannelId).ToList();
-        }
-        var modMailLogChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_LOG]);
-        await LogClosingHeader(closedthread, messagesToLog.Count(), note, modMailLogChannel, userObj);
-
-        await LogModMailThreadMessagesToModmailLog(closedthread, note, messagesToLog, modMailLogChannel);
-        await (channel as SocketTextChannel).DeleteAsync();
+        SocketGuildUser userObj = guild.GetUser(closedThread.UserId);
         // only send the user a dm, in case the user initiated, if we use contact it should not happen
-        if(userObj != null && messagesToLog.Count() > 0)
+        if(userObj != null && messagesToLogCount > 0)
         {
             await userObj.SendMessageAsync(embed: ModMailEmbedHandler.GetClosingEmbed());
         }
+    }
+
+    public async Task CloseThreadSilently(ISocketMessageChannel channel, string note)
+    { 
+      var closedThread = CloseThreadInDb(channel);  
+      await DeleteChannelAndLogThread(closedThread, channel, note);
     }
 
     
@@ -384,7 +398,7 @@ namespace OnePlusBot.Base
         var modMailLogChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_LOG]);
         await LogDisablingHeader(closedthread, messagesToLog.Count(), note, modMailLogChannel, userObj, until);
 
-        await LogModMailThreadMessagesToModmailLog(closedthread, note, messagesToLog, modMailLogChannel);
+        await LogModMailThreadMessagesToModmailLog(closedthread, messagesToLog, modMailLogChannel);
         await (channel as SocketTextChannel).DeleteAsync();
 
         if(userObj != null)

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -38,6 +38,8 @@ namespace OnePlusBot.Data.Models
         public static readonly string WARN_LOG = "warnlog";
         public static readonly string LEAVE_LOG = "leavelog";
 
+        public static readonly string NAME_LOG = "namelog";
+
         public static readonly List<string> POST_TARGETS = 
                               new List<string> { 
                                 OFFTOPIC, JOIN_LOG, BAN_LOG, 
@@ -45,7 +47,8 @@ namespace OnePlusBot.Data.Models
                                 MODMAIL_LOG, MODMAIL_NOTIFICATION, 
                                 MUTE_LOG, NEWS, PROFANITY_QUEUE, 
                                 STARBOARD, UNBAN_LOG, SUGGESTIONS, 
-                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG
+                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG,
+                                NAME_LOG
                               };
       
     }

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -38,8 +38,6 @@ namespace OnePlusBot.Data.Models
         public static readonly string WARN_LOG = "warnlog";
         public static readonly string LEAVE_LOG = "leavelog";
 
-        public static readonly string NAME_LOG = "namelog";
-
         public static readonly List<string> POST_TARGETS = 
                               new List<string> { 
                                 OFFTOPIC, JOIN_LOG, BAN_LOG, 
@@ -47,8 +45,7 @@ namespace OnePlusBot.Data.Models
                                 MODMAIL_LOG, MODMAIL_NOTIFICATION, 
                                 MUTE_LOG, NEWS, PROFANITY_QUEUE, 
                                 STARBOARD, UNBAN_LOG, SUGGESTIONS, 
-                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG,
-                                NAME_LOG
+                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG
                               };
       
     }

--- a/src/OnePlusBot/Modules/ModMail.cs
+++ b/src/OnePlusBot/Modules/ModMail.cs
@@ -94,6 +94,12 @@ namespace OnePlusBot.Modules
             return CustomResult.FromSuccess();
         }
 
+
+        /// <summary>
+        /// Closes the thread with the given note
+        /// </summary>
+        /// <param name="note">Note to be used for logging</param>
+        /// <returns>Result whether or not the closing was successful</returns>
         [
             Command("close", RunMode = RunMode.Async),
             Summary("Closes the modmail thread"),
@@ -106,6 +112,11 @@ namespace OnePlusBot.Modules
             return CustomResult.FromIgnored();
         }
 
+        /// <summary>
+        /// Closes the thread silently with the given note
+        /// </summary>
+        /// <param name="note">Note to be used for logging</param>
+        /// <returns>Result whether or not the closing was succesful</returns>
         [
             Command("closeSilently", RunMode = RunMode.Async),
             Summary("Closes the thread without notifying the user"),

--- a/src/OnePlusBot/Modules/ModMail.cs
+++ b/src/OnePlusBot/Modules/ModMail.cs
@@ -7,6 +7,7 @@ using OnePlusBot.Helpers;
 using OnePlusBot.Data.Models;
 using OnePlusBot.Data;
 using Discord;
+using System.Runtime.InteropServices;
 
 namespace OnePlusBot.Modules
 {
@@ -99,9 +100,21 @@ namespace OnePlusBot.Modules
             RequireRole("staff"),
             RequireModMailContext
         ]
-        public async Task<RuntimeResult> CloseThread([Remainder] string note)
+        public async Task<RuntimeResult> CloseThread([Optional] [Remainder] string note)
         {
-            await new ModMailManager().CloseThread(Context.Message, Context.Channel, Context.User, note);
+            await new ModMailManager().CloseThread(Context.Channel, note);
+            return CustomResult.FromIgnored();
+        }
+
+        [
+            Command("closeSilently", RunMode = RunMode.Async),
+            Summary("Closes the thread without notifying the user"),
+            RequireRole("staff"),
+            RequireModMailContext
+        ]
+        public async Task<RuntimeResult> CloseThreadSilently([Optional] [Remainder] string note)
+        {
+            await new ModMailManager().CloseThreadSilently(Context.Channel, note);
             return CustomResult.FromIgnored();
         }
 


### PR DESCRIPTION
With this PR there are even listener after the user joined the guild already to check if the nickname/username is allowed according to rules.
If a nickname is set, the username is ignored, and only the nickname checked.

If a modmail thread is opened for the user (they are used to notify the users about the username rules), a notification is sent to that channel in case the user changed the username or nickname, so moderators are aware that the user might have set the nickname accordingly.

Also added a command to modmail to be able to close a modmail thread silently, to not notify the user and also made the note, when closing, optional.