### PR TITLE
Added ability to disable commands in specific channel groups

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -343,4 +343,39 @@ CREATE TABLE `PostTargets` (
  UNIQUE KEY `name` (`name`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+--
+-- Table structure for table `Commands`
+--
+
+CREATE TABLE `Commands` (
+ `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
+ `module_id` int(10) unsigned NOT NULL,
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=246 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `CommandModules`
+--
+
+CREATE TABLE `CommandModules` (
+ `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
+ `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=25 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `CommandInChannelGroup`
+--
+
+CREATE TABLE `CommandInChannelGroup` (
+ `command_id` int(10) unsigned NOT NULL,
+ `channel_group_id` int(10) unsigned NOT NULL,
+ `disabled` tinyint(4) NOT NULL,
+ PRIMARY KEY (`command_id`,`channel_group_id`),
+ KEY `fk_channel_group_reference` (`channel_group_id`),
+ CONSTRAINT `fk_channel_group_reference` FOREIGN KEY (`channel_group_id`) REFERENCES `ChannelGroups` (`id`),
+ CONSTRAINT `fk_command_reference` FOREIGN KEY (`command_id`) REFERENCES `Commands` (`id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -1,3 +1,4 @@
+using System.Net.Http.Headers;
 using System;
 using System.Threading.Tasks;
 using Discord;
@@ -15,7 +16,7 @@ namespace OnePlusBot.Base
 {
     public class ChannelManager
     {
-        public void createChannelGroup(string name)
+        public void createChannelGroup(string name, string type)
         {
             using(var db = new Database())
             {
@@ -26,6 +27,7 @@ namespace OnePlusBot.Base
                 }
                 var channelGroup = new ChannelGroup();
                 channelGroup.Name = name;
+                channelGroup.ChannelGroupType = type;
                 db.ChannelGroups.Add(channelGroup);
                 
                 db.SaveChanges();
@@ -185,20 +187,35 @@ namespace OnePlusBot.Base
             }
         }
 
-        public Collection<Embed> GetChannelListEmbed()
+        /// <summary>
+        /// Renders the configured channel groups of the given type (if type is null, all of them) into a collection of embeds.
+        /// Included information is: xp disabled, profanity check disabled, invite check disabled, whether or not the group is disabled and the type of the group
+        /// </summary>
+        /// <param name="type">The type of group you want to render, if null, it will render all</param>
+        /// <returns>Collection of <see cref="Discord.Embed"> representing the channel groups </returns>
+        public Collection<Embed> GetChannelListEmbed(string type)
         {
             Collection<Embed> embedsToPost = new Collection<Embed>();
             using(var db = new Database())
             {
                 var currentEmbedBuilder = new EmbedBuilder();
                 currentEmbedBuilder.WithTitle("Available channel groups");
-                var channelGroups = db.ChannelGroups.Include(ch => ch.Channels).ToList();
+                List<ChannelGroup> channelGroups;
+                if(type != null)
+                {
+                   channelGroups = db.ChannelGroups.Where(grp => grp.ChannelGroupType == type).Include(ch => ch.Channels).ToList();
+                }
+                else
+                {
+                  channelGroups = db.ChannelGroups.Include(ch => ch.Channels).ToList();
+                }
+               
                 var count = 0;
                 foreach(var group in channelGroups)
                 {
                     count++;
                     var disabledIndicator = group.Disabled ? " (Disabled)" : "";
-                    currentEmbedBuilder.AddField($"**{group.Name}**{disabledIndicator}, XP exempt: {group.ExperienceGainExempt}  Profanity check exempt: {group.ProfanityCheckExempt}, InviteCheck exempt: {group.InviteCheckExempt}", getChannelsAsMentions(group.Channels));
+                    currentEmbedBuilder.AddField($"**{group.Name}** {group.ChannelGroupType} {disabledIndicator}, XP exempt: {group.ExperienceGainExempt}  Profanity check exempt: {group.ProfanityCheckExempt}, InviteCheck exempt: {group.InviteCheckExempt}", getChannelsAsMentions(group.Channels));
                     if(((count % EmbedBuilder.MaxFieldCount) == 0) && group != channelGroups.Last())
                     {
                         embedsToPost.Add(currentEmbedBuilder.Build());
@@ -212,9 +229,9 @@ namespace OnePlusBot.Base
             return embedsToPost;
         }
 
-        public async Task ListChannelGroups(ISocketMessageChannel channelToRespondIn)
+        public async Task ListChannelGroups(ISocketMessageChannel channelToRespondIn, string type)
         {
-            var embedsToPost = GetChannelListEmbed();
+            var embedsToPost = GetChannelListEmbed(type);
             foreach(Embed embed in embedsToPost)
             {
                 await channelToRespondIn.SendMessageAsync(embed: embed);
@@ -243,7 +260,7 @@ namespace OnePlusBot.Base
                 var xpDisabled = false;
                 foreach(var groupMember in perms)
                 {
-                    if(!groupMember.Group.Disabled)
+                    if(!groupMember.Group.Disabled && groupMember.Group.ChannelGroupType == ChannelGroupType.CHECKS)
                     {
                         profanityDisabled |= groupMember.Group.ProfanityCheckExempt;
                         inviteLinksDisabled |= groupMember.Group.InviteCheckExempt;
@@ -280,22 +297,46 @@ namespace OnePlusBot.Base
             }
         }
 
-        public async Task ListCommandsWithGroups(ISocketMessageChannel channelToRespondIn)
+        public void ChangeChannelGroupTypeTo(string groupName, string newType)
+        {
+          if(!ChannelGroupType.TYPES.Where(n => n == newType).Any())
+          {
+            throw new ConfigurationException("Group type not valid");
+          }
+          using(var db = new Database())
+          {
+            var channelGroup = db.ChannelGroups.Where(grp => grp.Name == groupName);
+            if(!channelGroup.Any())
+            {
+              throw new NotFoundException("Channel group not found");
+            }
+            channelGroup.First().ChannelGroupType = newType;
+            db.SaveChanges();
+          }
+        }
+
+        public async Task ListGroupsWithCommands(ISocketMessageChannel channelToRespondIn)
         {
           EmbedBuilder builder = new EmbedBuilder();
           builder.WithTitle("Command channel group overview");
           StringBuilder sb = new StringBuilder();
           using(var db = new Database()){
-            var commands = db.Commands.Include(c => c.GroupsCommandIsIn).ThenInclude(g => g.ChannelGroupReference);
-            foreach(var cmd in commands){
-              sb.Append($"{cmd.Name}: ");
-              if(cmd.GroupsCommandIsIn == null || cmd.GroupsCommandIsIn.Count() == 0){
-                sb.Append("No groups.\n");
+            var commandGroups = db.ChannelGroups.Include(grp => grp.Commands).ThenInclude(ch => ch.CommandReference);
+            foreach(var grp in commandGroups)
+            {
+              var disabledPart = grp.Disabled ? "(Disabled)" : "";
+              sb.Append($"{grp.Name} {grp.ChannelGroupType} {disabledPart}: ");
+              if(grp.Commands == null || grp.Commands.Count() == 0){
+                sb.Append("No commands.\n");
                 continue;
               }
-              foreach(var group in cmd.GroupsCommandIsIn){
-                var disabledPart = group.Disabled ? "(Disabled)" : "";
-                sb.Append($"`{group.ChannelGroupReference.Name}` {disabledPart},");
+              foreach(var cmd in grp.Commands)
+              {
+                var commandDisabledPart = cmd.Disabled ? "(Disabled)" : "";
+                sb.Append($"`{cmd.CommandReference.Name}` {commandDisabledPart}");
+                if(cmd != grp.Commands.Last()){
+                  sb.Append(", ");
+                }
               }
               sb.Append("\n");
              

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -279,5 +279,30 @@ namespace OnePlusBot.Base
                 db.SaveChanges();
             }
         }
+
+        public async Task ListCommandsWithGroups(ISocketMessageChannel channelToRespondIn)
+        {
+          EmbedBuilder builder = new EmbedBuilder();
+          builder.WithTitle("Command channel group overview");
+          StringBuilder sb = new StringBuilder();
+          using(var db = new Database()){
+            var commands = db.Commands.Include(c => c.GroupsCommandIsIn).ThenInclude(g => g.ChannelGroupReference);
+            foreach(var cmd in commands){
+              sb.Append($"{cmd.Name}: ");
+              if(cmd.GroupsCommandIsIn == null || cmd.GroupsCommandIsIn.Count() == 0){
+                sb.Append("No groups.\n");
+                continue;
+              }
+              foreach(var group in cmd.GroupsCommandIsIn){
+                var disabledPart = group.Disabled ? "(Disabled)" : "";
+                sb.Append($"`{group.ChannelGroupReference.Name}` {disabledPart},");
+              }
+              sb.Append("\n");
+             
+            }
+          }
+          builder.WithDescription(sb.ToString());
+          await channelToRespondIn.SendMessageAsync(embed: builder.Build());
+        }
     }
 }

--- a/src/OnePlusBot/Base/ChannelManager.cs
+++ b/src/OnePlusBot/Base/ChannelManager.cs
@@ -16,6 +16,13 @@ namespace OnePlusBot.Base
 {
     public class ChannelManager
     {
+        /// <summary>
+        /// Creates the channel group in the database with the given channel group type
+        /// </summary>
+        /// <param name="name">The name of the channel group which should be created</param>
+        /// <param name="type">The type of the channel group to create</param>
+        /// <exception cref="OnePlusBot.Base.Errors.ConfigurationException">In case a channel group already exists with this name</exception>
+      
         public void createChannelGroup(string name, string type)
         {
             using(var db = new Database())
@@ -23,7 +30,7 @@ namespace OnePlusBot.Base
                 var existingGroup = db.ChannelGroups.Where(grp => grp.Name == name).FirstOrDefault();
                 if(existingGroup != null)
                 {
-                    throw new NotFoundException("Channel group with name already exists.");
+                    throw new ConfigurationException("Channel group with name already exists.");
                 }
                 var channelGroup = new ChannelGroup();
                 channelGroup.Name = name;
@@ -229,6 +236,12 @@ namespace OnePlusBot.Base
             return embedsToPost;
         }
 
+        /// <summary>
+        /// Creates the embeds containing the channels from the given group and posts them towards the given channel
+        /// </summary>
+        /// <param name="channelToRespondIn">The <see cref="Discord.WebSocket.ISocketMessageChannel"> object where the embeds should be posted towards</param>
+        /// <param name="type">The of the channel groups to display</param>
+        /// <returns>Task</returns>
         public async Task ListChannelGroups(ISocketMessageChannel channelToRespondIn, string type)
         {
             var embedsToPost = GetChannelListEmbed(type);
@@ -297,6 +310,13 @@ namespace OnePlusBot.Base
             }
         }
 
+        /// <summary>
+        /// Changes the type of the channel group identified by the channel group name to the given channel group type (if its a valid one)
+        /// </summary>
+        /// <param name="groupName">The name of the group to change the type for</param>
+        /// <param name="newType">The type the group should be changed to (needs to be a valid group type)</param>
+        /// <exception cref="OnePlusBot.Base.Errors.ConfigurationException">In case the type is not valid</exception>
+        /// <exception cref="OnePlusBot.Base.Errors.NotFoundException">In case no channel group with that name is found</exception>
         public void ChangeChannelGroupTypeTo(string groupName, string newType)
         {
           if(!ChannelGroupType.TYPES.Where(n => n == newType).Any())
@@ -315,6 +335,12 @@ namespace OnePlusBot.Base
           }
         }
 
+        /// <summary>
+        /// Creates embed and posts the embeds towards the given channel containing information about all the channel groups of type COMMAND.
+        /// In case there are channels configured for this group, they get printed as well.
+        /// </summary>
+        /// <param name="channelToRespondIn">The <see cref="Discord.WebSocket.ISocketMessageChannel"> object where the embeds should be posted towards</param>
+        /// <returns>Task</returns>
         public async Task ListGroupsWithCommands(ISocketMessageChannel channelToRespondIn)
         {
           EmbedBuilder builder = new EmbedBuilder();

--- a/src/OnePlusBot/Base/CommandDisabledCheck.cs
+++ b/src/OnePlusBot/Base/CommandDisabledCheck.cs
@@ -1,10 +1,8 @@
-using System.Runtime.CompilerServices;
 using System.Linq;
 using System;
 using System.Threading.Tasks;
 using Discord.Commands;
-using Discord.WebSocket;
-using Discord;
+using OnePlusBot.Data.Models;
 
 
 namespace OnePlusBot.Base
@@ -15,19 +13,24 @@ namespace OnePlusBot.Base
         public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             var channelId = context.Channel.Id;
-            var commandInChannel = Global.CommandChannelGroups.Where(
-              coChGrp => coChGrp.CommandReference.Name == command.Name &&
-              coChGrp.ChannelGroupReference.Channels.
-                Where(ch => ch.ChannelId == channelId).Any());
-            if(!commandInChannel.Any())
+            var commandFromDb = Global.Commands.Where(cmd => cmd.Name == command.Name);
+            var result = false;
+            if(commandFromDb.Any())
+            {
+              result = commandFromDb.First().CommandEnabled(context.Channel.Id);
+            }
+            else
+            {
+              result = false;
+            }
+            if(result)
             {
               return Task.FromResult(PreconditionResult.FromSuccess());
             }
-            if(commandInChannel.Where(co => co.Disabled).Any())
+            else 
             {
-              return Task.FromResult(PreconditionResult.FromError("Command is disabled in this channel"));
+              return Task.FromResult(PreconditionResult.FromError("Command disabled in this channel"));
             }
-            return Task.FromResult(PreconditionResult.FromSuccess());
         }
     }
 }

--- a/src/OnePlusBot/Base/CommandDisabledCheck.cs
+++ b/src/OnePlusBot/Base/CommandDisabledCheck.cs
@@ -2,14 +2,21 @@ using System.Linq;
 using System;
 using System.Threading.Tasks;
 using Discord.Commands;
-using OnePlusBot.Data.Models;
-
 
 namespace OnePlusBot.Base
 {
-
+    /// <summary>
+    /// Executed before most commands are executed (commands related to disabling commands are exempt from this)
+    /// </summary>
     public class CommandDisabledCheck : PreconditionAttribute
     {
+        /// <summary>
+        /// Checks whether the given command should be able to be executed in the given channel
+        /// </summary>
+        /// <param name="context">The <see cref="Discord.Commands.ICommandContext"> object containing context for the command</param>
+        /// <param name="command">The <see cref="Discord.Commands.CommandInfo"> object containing infor about the command</param>
+        /// <param name="services">The <see cref="System.IServiceProvider"> service provider object of this bot</param>
+        /// <returns><see cref="Discord.Commands.PreconditionResult"> result whether or not the command should be executed.</returns>
         public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
         {
             var channelId = context.Channel.Id;

--- a/src/OnePlusBot/Base/CommandDisabledCheck.cs
+++ b/src/OnePlusBot/Base/CommandDisabledCheck.cs
@@ -1,0 +1,33 @@
+using System.Runtime.CompilerServices;
+using System.Linq;
+using System;
+using System.Threading.Tasks;
+using Discord.Commands;
+using Discord.WebSocket;
+using Discord;
+
+
+namespace OnePlusBot.Base
+{
+
+    public class CommandDisabledCheck : PreconditionAttribute
+    {
+        public override Task<PreconditionResult> CheckPermissionsAsync(ICommandContext context, CommandInfo command, IServiceProvider services)
+        {
+            var channelId = context.Channel.Id;
+            var commandInChannel = Global.CommandChannelGroups.Where(
+              coChGrp => coChGrp.CommandReference.Name == command.Name &&
+              coChGrp.ChannelGroupReference.Channels.
+                Where(ch => ch.ChannelId == channelId).Any());
+            if(!commandInChannel.Any())
+            {
+              return Task.FromResult(PreconditionResult.FromSuccess());
+            }
+            if(commandInChannel.Where(co => co.Disabled).Any())
+            {
+              return Task.FromResult(PreconditionResult.FromError("Command is disabled in this channel"));
+            }
+            return Task.FromResult(PreconditionResult.FromSuccess());
+        }
+    }
+}

--- a/src/OnePlusBot/Base/ConfigurationStep.cs
+++ b/src/OnePlusBot/Base/ConfigurationStep.cs
@@ -177,6 +177,11 @@ namespace OnePlusBot.Base {
            
         }
 
+        /// <summary>
+        /// Checks what kind of action should be taked based on the kind of reaction which was added to the message
+        /// </summary>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> reaction which was added by the user</param>
+        /// <returns></returns>
         public async Task<bool> HandleCallbackAsync(SocketReaction reaction)
         {
             await RemoveMessagesOnNextProgression();

--- a/src/OnePlusBot/Base/ConfigurationStep.cs
+++ b/src/OnePlusBot/Base/ConfigurationStep.cs
@@ -185,7 +185,14 @@ namespace OnePlusBot.Base {
             {
                 if(actionToExecute.Emote.Equals(emote))
                 {
-                    await actionToExecute.Action(this);
+                    try
+                    {
+                      await actionToExecute.Action(this);
+                    }
+                    catch(Exception e)
+                    {
+                      await Context.Channel.SendMessageAsync(e.Message);
+                    }
                     break;
                 }
             }

--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -9,6 +9,11 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Timers;
 using OnePlusBot.Data.Models;
+using OnePlusBot.Data;
+using System.Linq;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;
+
 
 namespace OnePlusBot.Base
 {
@@ -97,6 +102,8 @@ namespace OnePlusBot.Base
 
             FillReactionActions();
 
+            UpdateCommandsInDb(services.GetRequiredService<CommandService>());
+
             await Task.Delay(-1);
         }
 
@@ -117,6 +124,62 @@ namespace OnePlusBot.Base
             AddReactionActions.Add(new ProfanityReportReactionAdded());
             RemoveReactionActions.Add(new RemoveRoleReactionAction());
             RemoveReactionActions.Add(new StarboardRemovedReactionAction());
+        }
+
+        private static void UpdateCommandsInDb(CommandService commandHandler)
+        {
+          using(var db = new Database())
+          {
+            var modules = commandHandler.Modules;
+            foreach(var module in modules)
+            {
+              var moduleQuery = db.Modules.Where(mo => mo.Name == module.Name);
+              CommandModule moduleToUse;
+              if(!moduleQuery.Any())
+              {
+                var newModule = new CommandModule();
+                newModule.Name = module.Name;
+                db.Modules.Add(newModule);
+                db.SaveChanges();
+                moduleToUse = newModule; 
+              }
+              else
+              {
+                moduleToUse = moduleQuery.First();
+              }
+              
+              foreach(var command in module.Commands)
+              {
+                if(!db.Commands.Where(com => com.Name == command.Name).Any())
+                {
+                  var commandToCreate = new Command();
+                  commandToCreate.Name = command.Name;
+                  commandToCreate.ModuleId = moduleToUse.ID;
+                  db.Commands.Add(commandToCreate);
+                }
+              }
+              db.SaveChanges();
+              var commandsInDb = db.Modules.Include(mo => mo.Commands).Where(mo => mo.Name == module.Name).FirstOrDefault();
+              if(commandsInDb != null){
+                var commandsToDelete = new List<Command>();
+                foreach(var command in commandsInDb.Commands)
+                {
+                   if(!module.Commands.Where(co => co.Name == command.Name).Any()) 
+                   {
+                    commandsToDelete.Add(command);
+                   }
+                }
+                foreach(var toDelete in commandsToDelete)
+                {
+                  db.CommandInChannelGroups.RemoveRange(db.CommandInChannelGroups.Where(co => co.CommandID == toDelete.ID));
+                  commandsInDb.Commands.Remove(toDelete);
+                }
+              }
+              
+            }
+            db.SaveChanges();
+          }
+         
         }
 
         private static void OnTimerElapsed(object sender, ElapsedEventArgs e)

--- a/src/OnePlusBot/Base/CustomResult.cs
+++ b/src/OnePlusBot/Base/CustomResult.cs
@@ -1,7 +1,4 @@
 ﻿using Discord.Commands;
-using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace OnePlusBot.Base
 {

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -33,7 +33,7 @@ namespace OnePlusBot.Base
 
         public static List<InviteLink> InviteLinks { get; set; }
 
-        public static List<CommandInChannelGroup> CommandChannelGroups { get; set; }
+        public static List<Command> Commands { get; set; }
 
         public static ulong CommandExecutorId { get; set; }
 
@@ -120,7 +120,7 @@ namespace OnePlusBot.Base
             ModMailThreads = new List<ModMailThread>();
             ReportedProfanities = new List<UsedProfanity>();
             RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
-            CommandChannelGroups = new List<CommandInChannelGroup>();
+            Commands = new  List<Command>();
             LoadGlobal();
         }
 
@@ -250,11 +250,8 @@ namespace OnePlusBot.Base
                 FAQCommandChannels = ReadChannels;
                 FAQCommands = db.FAQCommands.ToList();
 
-                CommandChannelGroups = db.CommandInChannelGroups
-                .Include(comIChGrp => comIChGrp.ChannelGroupReference)
-                .Include(comIChGrp => comIChGrp.ChannelGroupReference.Channels)
-                .Include(comIChGrp => comIChGrp.CommandReference)
-                .Include(comIChGrp => comIChGrp.CommandReference.Module).ThenInclude(mo => mo.Commands)
+                Commands = db.Commands
+                .Include(co => co.GroupsCommandIsIn).ThenInclude(grp => grp.ChannelGroupReference).ThenInclude(ch => ch.Channels)
                 .ToList();
             }
 
@@ -262,7 +259,7 @@ namespace OnePlusBot.Base
         }
 
         public static class OnePlusEmote {
-            public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
+            public static IEmote SUCCESS = Emote.Parse("<:snow_avasnow_avasnow_avasnow_ava:604671718254182411>");
             public static IEmote FAIL = new Emoji("⚠");
             public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
             public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -33,6 +33,8 @@ namespace OnePlusBot.Base
 
         public static List<InviteLink> InviteLinks { get; set; }
 
+        public static List<CommandInChannelGroup> CommandChannelGroups { get; set; }
+
         public static ulong CommandExecutorId { get; set; }
 
         public static ulong StarboardStars { get; set; }
@@ -118,6 +120,7 @@ namespace OnePlusBot.Base
             ModMailThreads = new List<ModMailThread>();
             ReportedProfanities = new List<UsedProfanity>();
             RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
+            CommandChannelGroups = new List<CommandInChannelGroup>();
             LoadGlobal();
         }
 
@@ -246,6 +249,13 @@ namespace OnePlusBot.Base
 
                 FAQCommandChannels = ReadChannels;
                 FAQCommands = db.FAQCommands.ToList();
+
+                CommandChannelGroups = db.CommandInChannelGroups
+                .Include(comIChGrp => comIChGrp.ChannelGroupReference)
+                .Include(comIChGrp => comIChGrp.ChannelGroupReference.Channels)
+                .Include(comIChGrp => comIChGrp.CommandReference)
+                .Include(comIChGrp => comIChGrp.CommandReference.Module).ThenInclude(mo => mo.Commands)
+                .ToList();
             }
 
             ReloadModmailThreads();

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -259,7 +259,7 @@ namespace OnePlusBot.Base
         }
 
         public static class OnePlusEmote {
-            public static IEmote SUCCESS = Emote.Parse("<:snow_avasnow_avasnow_avasnow_ava:604671718254182411>");
+            public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
             public static IEmote FAIL = new Emoji("⚠");
             public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
             public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -52,6 +52,12 @@ namespace OnePlusBot.Data
 
         public DbSet<ChannelInGroup> ChannelGroupMembers { get; set; }
 
+        public DbSet<Command> Commands { get; set; }
+
+        public DbSet<CommandModule> Modules { get; set; }
+
+        public DbSet<CommandInChannelGroup> CommandInChannelGroups { get; set; }
+
         // TODO needs to be replaced with proper dependency injection
         [Obsolete]
         public static readonly LoggerFactory LoggerFactory
@@ -91,6 +97,7 @@ namespace OnePlusBot.Data
             modelBuilder.Entity<ThreadSubscriber>().HasKey(c => new { c.UserId, c.ModMailThreadId });
             modelBuilder.Entity<ThreadMessage>().HasKey(c => new { c.ChannelId, c.ChannelMessageId });
             modelBuilder.Entity<ChannelInGroup>().HasKey(c => new {c.ChannelId, c.ChannelGroupId});
+            modelBuilder.Entity<CommandInChannelGroup>().HasKey(c => new {c.CommandID, c.ChannelGroupId});
             modelBuilder.Entity<PostTarget>().HasIndex(p => p.Name).IsUnique();
         }
 

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -25,17 +25,17 @@ namespace OnePlusBot.Data.Models
 
         public bool ProfanityExempt()
         {
-            return this.GroupsChannelIsIn.Where(grp => grp.Group.ProfanityCheckExempt && !grp.Group.Disabled).FirstOrDefault() != null;
+            return this.GroupsChannelIsIn.Where(grp => grp.Group.ProfanityCheckExempt && !grp.Group.Disabled && grp.Group.ChannelGroupType == ChannelGroupType.CHECKS).FirstOrDefault() != null;
         }
 
         public bool InviteCheckExempt()
         {
-            return this.GroupsChannelIsIn.Where(grp => grp.Group.InviteCheckExempt && !grp.Group.Disabled).FirstOrDefault() != null;
+            return this.GroupsChannelIsIn.Where(grp => grp.Group.InviteCheckExempt && !grp.Group.Disabled  && grp.Group.ChannelGroupType == ChannelGroupType.CHECKS).FirstOrDefault() != null;
         }
 
         public bool ExperienceGainExempt()
         {
-            return this.GroupsChannelIsIn.Where(grp => grp.Group.ExperienceGainExempt && !grp.Group.Disabled).FirstOrDefault() != null;
+            return this.GroupsChannelIsIn.Where(grp => grp.Group.ExperienceGainExempt && !grp.Group.Disabled  && grp.Group.ChannelGroupType == ChannelGroupType.CHECKS).FirstOrDefault() != null;
         }
 
         public static readonly string STARBOARD = "starboard";

--- a/src/OnePlusBot/Data/Models/Channel.cs
+++ b/src/OnePlusBot/Data/Models/Channel.cs
@@ -23,19 +23,43 @@ namespace OnePlusBot.Data.Models
 
         public virtual ICollection<ChannelInGroup> GroupsChannelIsIn { get; set; }
 
+        /// <summary>
+        /// Returns true in case this channel is exempt from the profanity check. This means, its in at least *one* currently active group of type CHECKS, which is profanity exempt
+        /// </summary>
+        /// <returns></returns>
         public bool ProfanityExempt()
         {
-            return this.GroupsChannelIsIn.Where(grp => grp.Group.ProfanityCheckExempt && !grp.Group.Disabled && grp.Group.ChannelGroupType == ChannelGroupType.CHECKS).FirstOrDefault() != null;
+            return this.GroupsChannelIsIn.Where(
+              grp => grp.Group.ProfanityCheckExempt &&
+              !grp.Group.Disabled && 
+              grp.Group.ChannelGroupType == ChannelGroupType.CHECKS)
+            .Any();
         }
 
+        /// <summary>
+        /// Returns true in case this channel is exempt from the invite check. This means, its in at least *one* currently active group of type CHECKS, which is invite check exempt
+        /// </summary>
+        /// <returns></returns>
         public bool InviteCheckExempt()
         {
-            return this.GroupsChannelIsIn.Where(grp => grp.Group.InviteCheckExempt && !grp.Group.Disabled  && grp.Group.ChannelGroupType == ChannelGroupType.CHECKS).FirstOrDefault() != null;
+            return this.GroupsChannelIsIn.Where(
+              grp => grp.Group.InviteCheckExempt && 
+              !grp.Group.Disabled  && 
+              grp.Group.ChannelGroupType == ChannelGroupType.CHECKS)
+              .Any();
         }
 
+        // <summary>
+        /// Returns true in case this channel is exempt from experience gain. This means, its in at least *one* currently active group of type CHECKS, which has experience gain disabled
+        /// </summary>
+        /// <returns></returns>
         public bool ExperienceGainExempt()
         {
-            return this.GroupsChannelIsIn.Where(grp => grp.Group.ExperienceGainExempt && !grp.Group.Disabled  && grp.Group.ChannelGroupType == ChannelGroupType.CHECKS).FirstOrDefault() != null;
+            return this.GroupsChannelIsIn.Where(
+              grp => grp.Group.ExperienceGainExempt && 
+              !grp.Group.Disabled  && 
+              grp.Group.ChannelGroupType == ChannelGroupType.CHECKS)
+              .Any();
         }
 
         public static readonly string STARBOARD = "starboard";

--- a/src/OnePlusBot/Data/Models/ChannelGroup.cs
+++ b/src/OnePlusBot/Data/Models/ChannelGroup.cs
@@ -26,8 +26,25 @@ namespace OnePlusBot.Data.Models
         [Column("disabled")]
         public bool Disabled { get; set; }
 
+        [Column("channel_group_type")]
+        public string ChannelGroupType { get; set; }
 
         public virtual ICollection<ChannelInGroup> Channels { get; set; }
+
+        public virtual ICollection<CommandInChannelGroup> Commands { get; set; }     
       
     }
+
+      public static class ChannelGroupType {
+          public static string CHECKS = "CHECKS";
+
+          public static string FAQ = "FAQ";
+          
+          public static string COMMANDS = "COMMANDS";
+
+          public static List<string> TYPES =
+                              new List<string> { 
+                               CHECKS, FAQ, COMMANDS
+                              };
+        }
 }

--- a/src/OnePlusBot/Data/Models/Command.cs
+++ b/src/OnePlusBot/Data/Models/Command.cs
@@ -28,7 +28,19 @@ namespace OnePlusBot.Data.Models
 
         public bool CommandEnabled(ulong channelId)
         {
-            return this.GroupsCommandIsIn.Where(grp => !grp.Disabled && grp.ChannelGroupReference.Channels.Where(ch => ch.ChannelId == channelId).Any()).Any();
+            bool result = false;
+            var cmdGroups = this.GroupsCommandIsIn.Where(grp => grp.ChannelGroupReference.ChannelGroupType == ChannelGroupType.COMMANDS
+                                                          && !grp.ChannelGroupReference.Disabled
+                                                          && grp.ChannelGroupReference.Channels.Where(ch => ch.ChannelId == channelId).Any());
+            if(cmdGroups.Any())
+            {
+              result = this.GroupsCommandIsIn.Where(grp => !grp.Disabled).Any();
+            }
+            else 
+            {
+              result = true;
+            }
+          return result;
         }
     }
 }

--- a/src/OnePlusBot/Data/Models/Command.cs
+++ b/src/OnePlusBot/Data/Models/Command.cs
@@ -26,6 +26,15 @@ namespace OnePlusBot.Data.Models
         public virtual ICollection<CommandInChannelGroup> GroupsCommandIsIn { get; set; }
 
 
+        /// <summary>
+        /// Returns wheter or not the command should be considered enabled.
+        /// A command is enabled if:
+        /// its not configured in any channel group of type COMMANDS
+        /// its configured in *any* channel group of type COMMANDS, but its enabled in this group
+        /// its configured for groups of type COMMANDS, but these groups are disabled
+        /// </summary>
+        /// <param name="channelId">The id of the channel to check for</param>
+        /// <returns>bool wheter or not this command is enabled</returns>
         public bool CommandEnabled(ulong channelId)
         {
             bool result = false;

--- a/src/OnePlusBot/Data/Models/Command.cs
+++ b/src/OnePlusBot/Data/Models/Command.cs
@@ -1,0 +1,34 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("Commands")]
+    public class Command
+    {
+        [Key]
+        [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public uint ID { get; set; }
+        
+        [Column("name")]
+        public string Name { get; set; }
+
+        [Column("module_id")]
+        public uint ModuleId { get; set; }
+
+
+        [ForeignKey("ModuleId")]
+        public virtual CommandModule Module { get; set; }
+
+        public virtual ICollection<CommandInChannelGroup> GroupsCommandIsIn { get; set; }
+
+
+        public bool CommandEnabled(ulong channelId)
+        {
+            return this.GroupsCommandIsIn.Where(grp => !grp.Disabled && grp.ChannelGroupReference.Channels.Where(ch => ch.ChannelId == channelId).Any()).Any();
+        }
+    }
+}

--- a/src/OnePlusBot/Data/Models/CommandInChannelGroup.cs
+++ b/src/OnePlusBot/Data/Models/CommandInChannelGroup.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("CommandInChannelGroup")]
+    public class CommandInChannelGroup
+    {
+        [Column("command_id")]
+        public uint CommandID { get; set; }
+        
+        [Column("channel_group_id")]
+        public uint ChannelGroupId { get; set; }
+
+        [Column("disabled")]
+        public bool Disabled { get; set; }
+
+        [ForeignKey("CommandID")]
+        public virtual Command CommandReference { get; set; }
+
+        [ForeignKey("ChannelGroupId")]
+        public virtual ChannelGroup ChannelGroupReference { get; set; }
+    }
+}

--- a/src/OnePlusBot/Data/Models/CommandModule.cs
+++ b/src/OnePlusBot/Data/Models/CommandModule.cs
@@ -1,0 +1,20 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("CommandModules")]
+    public class CommandModule
+    {
+        [Key]
+        [Column("id")]
+        [DatabaseGenerated(DatabaseGeneratedOption.Identity)]
+        public uint ID { get; set; }
+        
+        [Column("name")]
+        public string Name { get; set; }
+
+        public virtual ICollection<Command> Commands { get; set; }
+    }
+}

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -685,12 +685,17 @@ namespace OnePlusBot.Modules
             return CustomResult.FromSuccess();
         }
 
+        /// <summary>
+        /// Sets the flag of the command identified by the given name in the channel group identified by the given group name to the given value
+        /// </summary>
+        /// <exception cref="OnePlusBot.Base.Errors.NotFoundException">In case no channel group or command with that name is found</exception>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("disableCommand"),
             Summary("Disables command in a specified channel group"),
             RequireRole(new string[]{"admin", "founder"})
         ]
-        public async Task<RuntimeResult> SetExpGainEnabled(string commandName, string channelGroupName, bool newValue)
+        public async Task<RuntimeResult> DisableCommandInGroup(string commandName, string channelGroupName, bool newValue)
         {
             using(var db = new Database())
             {

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -12,6 +12,7 @@ using Discord.WebSocket;
 using Discord.Net;
 using System.Collections.Generic;
 using System.Globalization;
+using OnePlusBot.Base.Errors;
 
 namespace OnePlusBot.Modules
 {
@@ -20,7 +21,8 @@ namespace OnePlusBot.Modules
         [
             Command("banid", RunMode = RunMode.Async),
             Summary("Bans specified user."),
-            RequireRole("staff")
+            RequireRole("staff"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> OBanAsync(ulong name, [Remainder] string reason = null)
         {
@@ -64,7 +66,8 @@ namespace OnePlusBot.Modules
             Command("ban", RunMode = RunMode.Async),
             Summary("Bans specified user."),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.BanMembers)
+            RequireBotPermission(GuildPermission.BanMembers),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> BanAsync(IGuildUser user, [Remainder] string reason = null)
         {
@@ -135,7 +138,8 @@ namespace OnePlusBot.Modules
             Command("kick", RunMode = RunMode.Async),
             Summary("Kicks specified user."),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.KickMembers)
+            RequireBotPermission(GuildPermission.KickMembers),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> KickAsync(IGuildUser user, [Remainder] string reason = null)
         {
@@ -156,7 +160,8 @@ namespace OnePlusBot.Modules
             Command("mute", RunMode=RunMode.Async),
             Summary("Mutes a specified user for a set amount of time"),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.ManageRoles)
+            RequireBotPermission(GuildPermission.ManageRoles),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> MuteUser(IGuildUser user,params string[] arguments)
         {
@@ -269,7 +274,8 @@ namespace OnePlusBot.Modules
             Command("unmute", RunMode=RunMode.Async),
             Summary("Unmutes a specified user"),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.ManageRoles)
+            RequireBotPermission(GuildPermission.ManageRoles),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> UnMuteUser(IGuildUser user)
         {
@@ -280,7 +286,8 @@ namespace OnePlusBot.Modules
             Command("purge", RunMode = RunMode.Async),
             Summary("Deletes specified amount of messages."),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.ManageMessages)
+            RequireBotPermission(GuildPermission.ManageMessages),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> PurgeAsync([Remainder] double delmsg)
         {
@@ -321,7 +328,8 @@ namespace OnePlusBot.Modules
             Command("warn"),
             Summary("Warn someone."),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.Administrator)
+            RequireBotPermission(GuildPermission.Administrator),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> WarnAsync(IGuildUser user, [Optional] [Remainder] string reason)
         {
@@ -385,7 +393,8 @@ namespace OnePlusBot.Modules
             Command("clearwarn"),
             Summary("Clear warnings."),
             RequireRole("staff"),
-            RequireBotPermission(GuildPermission.Administrator)
+            RequireBotPermission(GuildPermission.Administrator),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ClearwarnAsync(uint index)
         {
@@ -503,6 +512,7 @@ namespace OnePlusBot.Modules
         [
             Command("warnings"),
             Summary("Gets all warnings of given user"),
+            CommandDisabledCheck
         ]
         public async Task GetWarnings([Optional] IGuildUser user)
         {
@@ -565,7 +575,8 @@ namespace OnePlusBot.Modules
         [
             Command("setstars"),
             Summary("sets the amount required to appear on the starboard"),
-            RequireRole("staff")
+            RequireRole("staff"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> SetStars(string input)
         {
@@ -590,7 +601,8 @@ namespace OnePlusBot.Modules
         [
             Command("profanities"),
             Summary("Shows the actual and false profanities of a user"),
-            RequireRole("staff")
+            RequireRole("staff"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ShowProfanities(IGuildUser user)
         {
@@ -620,7 +632,8 @@ namespace OnePlusBot.Modules
         [
             Command("updateLevels", RunMode=RunMode.Async),
             Summary("Re-evaluates the experience, levels and assigns the roles to the users (takes a long time, use with care)"),
-            RequireRole(new string[]{"admin", "founder"})
+            RequireRole(new string[]{"admin", "founder"}),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> UpdateLevels([Optional] IGuildUser user)
         {
@@ -641,7 +654,8 @@ namespace OnePlusBot.Modules
         [
             Command("roleLevel"),
             Summary("Sets the level at which a role is given. If no parameters, shows the current role configuration"),
-            RequireRole(new string[]{"admin", "founder"})
+            RequireRole(new string[]{"admin", "founder"}),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> SetRoleToLevel([Optional] uint level, [Optional] ulong roleId)
         {
@@ -661,11 +675,57 @@ namespace OnePlusBot.Modules
         [
             Command("disableXpGain"),
             Summary("Enables/disables xp gain for a user"),
-            RequireRole(new string[]{"admin", "founder"})
+            RequireRole(new string[]{"admin", "founder"}),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> SetExpGainEnabled(IGuildUser user, bool newValue)
         {
              new ExpManager().SetXPDisabledTo(user, newValue);
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("disableCommand"),
+            Summary("Disables command in a specified channel group"),
+            RequireRole(new string[]{"admin", "founder"})
+        ]
+        public async Task<RuntimeResult> SetExpGainEnabled(string commandName, string channelGroupName, bool newValue)
+        {
+            using(var db = new Database())
+            {
+              var commandInChannelGroup = db.CommandInChannelGroups.Where(co => co.ChannelGroupReference.Name == channelGroupName && co.CommandReference.Name == commandName);
+              if(commandInChannelGroup.Any())
+              {
+                commandInChannelGroup.First().Disabled = newValue;
+              }
+              else 
+              {
+                var command = db.Commands.Where(co => co.Name == commandName);
+                if(command.Any())
+                {
+                  var channelGroup = db.ChannelGroups.Where(chgrp => chgrp.Name == channelGroupName);
+                  if(channelGroup.Any())
+                  {
+                    var newCommandInChannelGroup = new CommandInChannelGroup();
+                    newCommandInChannelGroup.ChannelGroupId = channelGroup.First().Id;
+                    newCommandInChannelGroup.CommandID = command.First().ID; 
+                    newCommandInChannelGroup.Disabled = newValue;
+                    db.CommandInChannelGroups.Add(newCommandInChannelGroup);
+                  } 
+                  else 
+                  {
+                    throw new NotFoundException("Channel group not found");
+                  }
+                }
+                else 
+                {
+                  throw new NotFoundException("Command not found");
+                }
+                
+              }
+              db.SaveChanges();
+            }
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -17,7 +17,8 @@ namespace OnePlusBot.Modules
             Command("createChannelGroup"),
             Summary("Creates a channel group to be used in other areas"),
             RequireRole("staff"),
-            Alias("createChGrp")
+            Alias("createChGrp"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> CreateChannelGroup(string groupName)
         {
@@ -30,7 +31,8 @@ namespace OnePlusBot.Modules
             Command("addGroupChannels"),
             Summary("Adds the mentioned channels to the given channel group"),
             RequireRole("staff"),
-            Alias("addGrpCh")
+            Alias("addGrpCh"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> AddToChannelGroup(string groupName, [Remainder] string text)
         {
@@ -48,7 +50,8 @@ namespace OnePlusBot.Modules
             Command("removeGroupChannels"),
             Summary("Removes the mentioned channels from the given channel group"),
             RequireRole("staff"),
-            Alias("rmGrpCh")
+            Alias("rmGrpCh"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> RemoveFromChannelGroup(string groupName, [Remainder] string text)
         {
@@ -66,7 +69,8 @@ namespace OnePlusBot.Modules
             Command("channelGroupAttributes"),
             Summary("Enables/disables the attribues in a certain channel group"),
             RequireRole(new string[]{"admin", "founder"}),
-            Alias("chGrpAtt")
+            Alias("chGrpAtt"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ToggleChannelGroupAttributes(string groupName, bool xpGain, [Optional] bool? profanityCheck, [Optional] Boolean? inviteCheck)
         {
@@ -79,7 +83,8 @@ namespace OnePlusBot.Modules
             Command("disableChannelGroup"),
             Summary("Enables/disables the profanity/invitecheck/xpgain flags for a group"),
             RequireRole(new string[]{"admin", "founder"}),
-            Alias("disableChGrp")
+            Alias("disableChGrp"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ToggleGroupDisabled(string groupName, bool newValue){
           
@@ -93,7 +98,8 @@ namespace OnePlusBot.Modules
             Command("setPostTarget"),
             Summary("Sets the target of a certain post"),
             RequireRole("staff"),
-            Alias("setTarget")
+            Alias("setTarget"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> SetPostTarget([Optional] string channelName, [Optional] ISocketMessageChannel channel)
         {
@@ -113,7 +119,8 @@ namespace OnePlusBot.Modules
             Command("renameChannelGroup"),
             Summary("Sets the target of a certain post"),
             RequireRole("staff"),
-            Alias("rnChGrp")
+            Alias("rnChGrp"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> RenameChannelGroup(string oldName, string newName)
         {
@@ -127,7 +134,8 @@ namespace OnePlusBot.Modules
             Command("listChannelGroups", RunMode=RunMode.Async),
             Summary("Prints all the channel groups of the server"),
             RequireRole("staff"),
-            Alias("listChGrp")
+            Alias("listChGrp"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ListChannelGroups()
         {
@@ -139,7 +147,8 @@ namespace OnePlusBot.Modules
             Command("showChannelConfig"),
             Summary("Show the configuration (disableXP/invitecheck/profanity) of the given or current channel"),
             RequireRole("staff"),
-            Alias("shChCfg")
+            Alias("shChCfg"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ShowChannelConfig([Optional] ISocketMessageChannel channel)
         {
@@ -161,12 +170,25 @@ namespace OnePlusBot.Modules
             Command("removeChannelGroup"),
             Summary("Deletes a channel group (will fail if the group is used anywhere)"),
             RequireRole("staff"),
-            Alias("rmChGrp")
+            Alias("rmChGrp"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> RemoveChannelGroup(string name)
         {
             new ChannelManager().RemoveChannelGroup(name);
             await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
+
+        [
+            Command("listCommands"),
+            Summary("Lists the groups a channel is configured to be disabled/enabled"),
+            RequireRole("staff"),
+            Alias("lsCmd")
+        ]
+        public async Task<RuntimeResult> ListCommandsWithGroups()
+        {
+            await new ChannelManager().ListCommandsWithGroups(Context.Channel);
             return CustomResult.FromSuccess();
         }
 

--- a/src/OnePlusBot/Modules/ChannelManagement.cs
+++ b/src/OnePlusBot/Modules/ChannelManagement.cs
@@ -14,6 +14,11 @@ namespace OnePlusBot.Modules
     public class Channels : InteractiveBase<SocketCommandContext>
     {
 
+        /// <summary>
+        /// Command responsibel for creating a channel group
+        /// </summary>
+        /// <param name="groupName">The name of the channel group to create</param>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("createChannelGroup", RunMode = RunMode.Async),
             Summary("Creates a channel group to be used in other areas"),
@@ -206,6 +211,11 @@ namespace OnePlusBot.Modules
             return CustomResult.FromSuccess();
         }
 
+
+        /// <summary>
+        /// Command used to display the groups of type COMMANDS, and the respective commands configured to be in this group
+        /// </summary>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("listGroupCommands"),
             Summary("Lists the groups which have specific commands defined for them"),
@@ -219,6 +229,12 @@ namespace OnePlusBot.Modules
             return CustomResult.FromSuccess();
         }
 
+
+        /// <summary>
+        /// Command used to change the type of a channel group
+        /// </summary>
+        /// <param name="groupName">The name of the channel group to change the type for</param>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("changeGroupType", RunMode = RunMode.Async),
             Summary("Changes the type of a group"),

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -165,7 +165,7 @@ namespace OnePlusBot.Modules
             };
 
             channelStep.beforeTextPosted = async (ConfigurationStep step) => {
-                var embeds = new ChannelManager().GetChannelListEmbed();
+                var embeds = new ChannelManager().GetChannelListEmbed(ChannelGroupType.FAQ);
                 foreach(var embed in embeds)
                 {
                     var postedMessage = await Context.Channel.SendMessageAsync(embed: embed);
@@ -183,7 +183,7 @@ namespace OnePlusBot.Modules
                     var groupNames = text.Split(' ');
                     bool foundAnyMatchingGroup = false;
                     foreach(var groupName in groupNames){
-                        var channelGroup = db.ChannelGroups.Where(ch => ch.Name == groupName).FirstOrDefault();
+                        var channelGroup = db.ChannelGroups.Where(ch => ch.Name == groupName && ch.ChannelGroupType == ChannelGroupType.FAQ).FirstOrDefault();
 
                         if(channelGroup != null)
                         {

--- a/src/OnePlusBot/Modules/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQConfiguration.cs
@@ -22,7 +22,8 @@ namespace OnePlusBot.Modules
         [
             Command("configureFAQ", RunMode = RunMode.Async),
             Summary("Configures the faq command entries."),
-            RequireRole("staff")
+            RequireRole("staff"),
+            CommandDisabledCheck
         ]
         public async Task ConfigureFAQ()
         {

--- a/src/OnePlusBot/Modules/Fun.cs
+++ b/src/OnePlusBot/Modules/Fun.cs
@@ -22,7 +22,8 @@ namespace OnePlusBot.Modules
     {
         [
             Command("8ball"),
-            Summary("Magic 8Ball for Discord!")
+            Summary("Magic 8Ball for Discord!"),
+            CommandDisabledCheck
         ]
         public async Task MagicBallAsync([Remainder] string search)
         {
@@ -53,7 +54,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("lovecalc"),
-            Summary("lovecalc search for Discord!")
+            Summary("lovecalc search for Discord!"),
+            CommandDisabledCheck
         ]
         public async Task LoveCalcAsync(string subjectA, [Remainder] string subjectB)
         {
@@ -64,7 +66,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("roulette"),
-            Summary("Russian roulette for Discord!")
+            Summary("Russian roulette for Discord!"),
+            CommandDisabledCheck
         ]
         public async Task RouletteAsync()
         {
@@ -80,7 +83,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("yt"),
-            Summary("YouTube search for Discord!")
+            Summary("YouTube search for Discord!"),
+            CommandDisabledCheck
         ]
         public async Task YouTubeAsync([Remainder] string parameter)
         {
@@ -106,7 +110,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("define"),
-            Summary("Grabs the first Urban Dictionary result based on the parameter.")
+            Summary("Grabs the first Urban Dictionary result based on the parameter."),
+            CommandDisabledCheck
         ]
         public async Task DefineAsync([Remainder] string searchquery)
         {
@@ -136,7 +141,8 @@ namespace OnePlusBot.Modules
         
         [
             Command("steamp"),
-            Summary("Steam profile banner for Discord!")
+            Summary("Steam profile banner for Discord!"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> SteampAsync([Remainder] string user)
         {
@@ -166,7 +172,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("starstats"),
-            Summary("Shows the statistics for the star board posts")
+            Summary("Shows the statistics for the star board posts"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> PrintStarStats()
         {

--- a/src/OnePlusBot/Modules/ModMail.cs
+++ b/src/OnePlusBot/Modules/ModMail.cs
@@ -97,6 +97,7 @@ namespace OnePlusBot.Modules
             Command("close", RunMode = RunMode.Async),
             Summary("Closes the modmail thread"),
             RequireRole("staff"),
+            RequireBotPermission(GuildPermission.ManageChannels),
             RequireModMailContext
         ]
         public async Task<RuntimeResult> CloseThread([Remainder] string note)
@@ -109,6 +110,7 @@ namespace OnePlusBot.Modules
             Command("edit", RunMode = RunMode.Async),
             Summary("edits your message in the modmail thread"),
             RequireRole("staff"),
+            RequireBotPermission(GuildPermission.ManageMessages),
             RequireModMailContext
         ]
         public async Task<RuntimeResult> EditMessage(params string[] parameters)
@@ -132,6 +134,7 @@ namespace OnePlusBot.Modules
             Command("disableThread", RunMode = RunMode.Async),
             Summary("disables and closes the modmail thread for a certain time period. The user will be notified and he will be able to contact modmail after the period again."),
             RequireRole("staff"),
+            RequireBotPermission(GuildPermission.ManageChannels),
             RequireModMailContext
         ]
         public async Task<RuntimeResult> DisableCurrentThread(params string[] arguments)
@@ -160,7 +163,8 @@ namespace OnePlusBot.Modules
         [
             Command("disableModmail"),
             Summary("Disables modmail for a certain time period. The target user will be able to contact modmail after the time has been reached."),
-            RequireRole("staff")
+            RequireRole("staff"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> DisableModMailForUser(IGuildUser user,  params string[] arguments)
         {
@@ -179,7 +183,8 @@ namespace OnePlusBot.Modules
         [
             Command("enableModmail"),
             Summary("Enables the modmail for a certain user immediatelly. No-op on users who have access."),
-            RequireRole("staff")
+            RequireRole("staff"),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> EnableModmailForUser(IGuildUser user)
         {
@@ -191,7 +196,9 @@ namespace OnePlusBot.Modules
         [
             Command("contact"),
             Summary("Opens a thread with the specified user"),
-            RequireRole("staff")
+            RequireRole("staff"),
+            RequireBotPermission(GuildPermission.ManageChannels),
+            CommandDisabledCheck
         ]
         public async Task<RuntimeResult> ContactUser(IGuildUser user)
         {
@@ -203,6 +210,7 @@ namespace OnePlusBot.Modules
             Command("delete"),
             Summary("Deletes your message within a modmail thread"),
             RequireRole("staff"),
+            RequireBotPermission(GuildPermission.ManageMessages),
             RequireModMailContext
         ]
         public async Task<RuntimeResult> DeleteMessage(params string[] parameters)

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -24,7 +24,8 @@ namespace OnePlusBot.Modules
 
         [
             Command("help"),
-            Summary("Lists all available commands.")
+            Summary("Lists all available commands."),
+            CommandDisabledCheck
         ]
         public async Task Help(string path = "")
         {
@@ -160,8 +161,11 @@ namespace OnePlusBot.Modules
             return output;
         }
 
-        [Command("faq")]
-        [Summary("Answers frequently asked questions with a predetermined response.")]
+        [
+          Command("faq"),
+          Summary("Answers frequently asked questions with a predetermined response."),
+          CommandDisabledCheck
+        ]
         public async Task FAQAsync([Optional] [Remainder] string parameter)
         {
             var contextChannel = Context.Channel;

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -502,6 +502,10 @@ namespace OnePlusBot.Modules
             return CustomResult.FromSuccess();
         }
 
+        /// <summary>
+        /// Command used to show the currently availble commands for the current channel, or for the given channel
+        /// </summary>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("availableCommands"),
             Summary("Shows the available commands for the current (or given channel) channel")

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -516,8 +516,10 @@ namespace OnePlusBot.Modules
           {
             var modules = db.Modules;
             foreach(var module in modules){
-              var commandsInModule = db.Commands.Include(c => c.GroupsCommandIsIn).Where(coChGrp => coChGrp.ModuleId == module.ID);
-              var commandGroups = Global.CommandChannelGroups.Where(chg => chg.CommandReference.ModuleId == module.ID);
+              var commandsInModule = db.Commands.Include(c => c.GroupsCommandIsIn)
+              .ThenInclude(grp => grp.ChannelGroupReference)
+              .ThenInclude(grp => grp.Channels)
+              .Where(coChGrp => coChGrp.ModuleId == module.ID);
               sb.Append($"\n Module: {module.Name} \n");
               if(commandsInModule.Any())
               {


### PR DESCRIPTION
Added the concept of channel group types, because the management of multiple channel groups with different configurations is made easier with that.

The command config is stored in the database, so this required a mechanism to store the commands (dynamically).
This PR needs changes in the DB.