### PR TITLE
moved emotes to the database, changed the way configurable self assignable roles are managed

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -375,4 +375,32 @@ CREATE TABLE `ExperienceLevels` (
  PRIMARY KEY (`level`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+--
+-- Table structure for table `Emotes`
+--
+
+CREATE TABLE `Emotes` (
+ `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+ `emote_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+ `animated` tinyint(4) NOT NULL DEFAULT '0',
+ `emote_id` bigint(20) unsigned NOT NULL DEFAULT '0',
+ `custom` tinyint(4) NOT NULL DEFAULT '1',
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+--
+-- Table structure for table `ReactionRoles`
+--
+
+CREATE TABLE `ReactionRoles` (
+ `emote_id` int(10) unsigned NOT NULL,
+ `role_id` bigint(20) unsigned NOT NULL,
+ `area` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+ PRIMARY KEY (`emote_id`,`role_id`),
+ KEY `fk_emote_role_ref` (`role_id`),
+ CONSTRAINT `fk_emote` FOREIGN KEY (`emote_id`) REFERENCES `Emotes` (`id`),
+ CONSTRAINT `fk_emote_role_ref` FOREIGN KEY (`role_id`) REFERENCES `Roles` (`role_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -351,6 +351,7 @@ CREATE TABLE `PostTargets` (
 -- Table structure for table `Commands`
 --
 
+DROP TABLE IF EXISTS `Commands`;
 CREATE TABLE `Commands` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -362,6 +363,7 @@ CREATE TABLE `Commands` (
 -- Table structure for table `CommandModules`
 --
 
+DROP TABLE IF EXISTS `CommandModules`;
 CREATE TABLE `CommandModules` (
  `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
  `name` text COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -372,6 +374,7 @@ CREATE TABLE `CommandModules` (
 -- Table structure for table `CommandInChannelGroup`
 --
 
+DROP TABLE IF EXISTS `CommandInChannelGroup`;
 CREATE TABLE `CommandInChannelGroup` (
  `command_id` int(10) unsigned NOT NULL,
  `channel_group_id` int(10) unsigned NOT NULL,
@@ -413,6 +416,7 @@ CREATE TABLE `ExperienceLevels` (
 -- Table structure for table `Emotes`
 --
 
+DROP TABLE IF EXISTS `Emotes`;
 CREATE TABLE `Emotes` (
  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
  `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
@@ -427,6 +431,7 @@ CREATE TABLE `Emotes` (
 -- Table structure for table `ReactionRoles`
 --
 
+DROP TABLE IF EXISTS `Emotes`;
 CREATE TABLE `ReactionRoles` (
  `emote_id` int(10) unsigned NOT NULL,
  `role_id` bigint(20) unsigned NOT NULL,

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -510,6 +510,13 @@ namespace OnePlusBot.Base
             await channel.Guild.GetTextChannel(Global.PostTargets[PostTarget.DELETE_LOG]).SendMessageAsync(embed: exceptionEmbed.Build());
         }
 
+        /// <summary>
+        /// Gets executed after a command has been completed. Reacts with either success reaction, a warn symbole accompanid with an error message or nothing, if the result is ignored.
+        /// </summary>
+        /// <param name="command">The <see cref="Discord.Commands.CommandInfo"> object which just finished executing</param>
+        /// <param name="context">The <see cref="Discord.ICommandContext"> in which the command finished executing</param>
+        /// <param name="result">The <see cref="Discord.Commands.IResult"> object containing the result of the command</param>
+        /// <returns></returns>
         private static async Task OnCommandExecutedAsync(Optional<CommandInfo> command, ICommandContext context, IResult result)
         {
             switch(result)

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -517,7 +517,7 @@ namespace OnePlusBot.Base
                 case PreconditionResult conditionResult:
                     if (conditionResult.IsSuccess)
                     {
-                        await context.Message.AddReactionAsync(Global.OnePlusEmote.SUCCESS);
+                        await context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.SUCCESS].GetAsEmote());
                     }
                     else
                     {
@@ -532,7 +532,7 @@ namespace OnePlusBot.Base
                     }
                     if (customResult.IsSuccess)
                     {
-                        await context.Message.AddReactionAsync(Global.OnePlusEmote.SUCCESS);
+                        await context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.SUCCESS].GetAsEmote());
                     }
                     else
                     {
@@ -555,31 +555,6 @@ namespace OnePlusBot.Base
                  }
                 break;
             }
-        }
-
-        private static async Task RoleReact(IUserMessage message)
-        {
-            Global.RoleManagerMessageId = message.Id;
-
-            await message.AddReactionsAsync(new IEmote[]
-            {
-
-                Emote.Parse("<a:1_:623172008540110859>"),
-                Emote.Parse("<a:2_:623171995684831252>"),
-                Emote.Parse("<a:X_:623171985542742027>"),
-                Emote.Parse("<a:3_:623171978198777856>"),
-                Emote.Parse("<a:3T:623171970326069268>"),
-                Emote.Parse("<a:5_:623171961400590366>"),
-                Emote.Parse("<a:5T:623171951510159371>"),
-                Emote.Parse("<a:6_:623171940647043092>"),
-                Emote.Parse("<a:6T:623171933407674369>"),
-                Emote.Parse("<a:7_:623171923706380329>"),
-                Emote.Parse("<a:7P:623171916236324874>"),
-                Emote.Parse("<a:7T:623171903447760906>"),
-                Emote.Parse("<a:7TP:625640956133113869>"),
-                new Emoji("\u2753"), 
-                new Emoji("\uD83D\uDCF0")
-            });
         }
 
         private static async Task ValidateSetupsMessage(SocketMessage message)
@@ -695,8 +670,8 @@ namespace OnePlusBot.Base
 
             await report.AddReactionsAsync(new IEmote[]
             {
-                Global.OnePlusEmote.OP_YES, 
-                Global.OnePlusEmote.OP_NO
+                Global.Emotes[Global.OnePlusEmote.OP_YES].GetAsEmote(), 
+                Global.Emotes[Global.OnePlusEmote.OP_NO].GetAsEmote()
             });
 
             var profanity = new UsedProfanity();
@@ -848,14 +823,6 @@ namespace OnePlusBot.Base
             if (channelId == Global.Channels[Channel.SETUPS])
             {
                 await ValidateSetupsMessage(message);
-            }
-            else if (channelId == Global.Channels[Channel.INFO])
-            {
-                if (message.Embeds.Count == 1)
-                {
-                    var userMessage = (IUserMessage) message;
-                    await RoleReact(userMessage);
-                }
             }
             else if (channelId == Global.Channels[Channel.REFERRAL])
             {

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -521,7 +521,7 @@ namespace OnePlusBot.Base
                     }
                     else
                     {
-                        await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);
+                        await context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.FAIL].GetAsEmote());
                         await context.Channel.SendMessageAsync(conditionResult.ErrorReason);
                     }
                     break;
@@ -536,7 +536,7 @@ namespace OnePlusBot.Base
                     }
                     else
                     {
-                        await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);
+                        await context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.FAIL].GetAsEmote());
                         await context.Channel.SendMessageAsync(customResult.Reason);
                     }
                     break;
@@ -548,7 +548,7 @@ namespace OnePlusBot.Base
                     if (result.ErrorReason == "Unknown command.")
                     return;
 
-                    await context.Message.AddReactionAsync(Global.OnePlusEmote.FAIL);                 
+                    await context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.FAIL].GetAsEmote());                 
 
                     await context.Channel.SendMessageAsync(result.ErrorReason);
                     return;

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -251,14 +251,14 @@ namespace OnePlusBot.Base
 
         public static class OnePlusEmote {
             public static string SUCCESS = "SUCCESS";
-            public static IEmote FAIL = new Emoji("⚠");
+            public static string FAIL = "FAIL";
             public static string OP_YES =  "OP_YES";
             public static string OP_NO = "OP_NO";
 
-            public static IEmote STAR = new Emoji("⭐");
-            public static IEmote LVL_2_STAR = new Emoji("🌟");
+            public static string STAR = "STAR";
+            public static string LVL_2_STAR = "LVL_2_STAR";
 
-            public static IEmote LVL_3_STAR = new Emoji("💫");
+            public static string LVL_3_STAR = "LVL_3_STAR";
 
             public static string LVL_4_STAR = "LVL_4_STAR";
 

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -256,6 +256,10 @@ namespace OnePlusBot.Base
             ReloadModmailThreads();
         }
 
+
+        /// <summary>
+        /// Class containing the keys by which the emotes are stored in the database
+        /// </summary>
         public static class OnePlusEmote {
             public static string SUCCESS = "SUCCESS";
             public static string FAIL = "FAIL";

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -13,7 +13,7 @@ namespace OnePlusBot.Base
 {
     internal static class Global
     {
-        private static ulong MessageId;
+        public static ulong InfoRoleManagerMessageId;
 
         public static Random Random { get; }
 
@@ -51,6 +51,8 @@ namespace OnePlusBot.Base
 
         public static ConcurrentDictionary<long, List<ulong>> RuntimeExp { get; set; }
 
+        public static Dictionary<string, StoredEmote> Emotes { get; set; }
+
         public static bool XPGainDisabled { get; set; }
 
         public static int XPGainRangeMin { get; set; }
@@ -82,21 +84,7 @@ namespace OnePlusBot.Base
                 }
             }
         }
-
-        public static ulong RoleManagerMessageId
-        {
-            get => MessageId;
-            set
-            {
-                using (var db = new Database())
-                {
-                    db.PersistentData
-                        .First(x => x.Name == "rolemanager_message_id")
-                        .Value = value;
-                    db.SaveChanges();
-                }
-            }
-        }
+      
 
        public static List<ProfanityCheck> ProfanityChecks { get; }
 
@@ -118,6 +106,7 @@ namespace OnePlusBot.Base
             ModMailThreads = new List<ModMailThread>();
             ReportedProfanities = new List<UsedProfanity>();
             RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
+            Emotes = new Dictionary<string, StoredEmote>();
             LoadGlobal();
         }
 
@@ -164,7 +153,7 @@ namespace OnePlusBot.Base
                     .First(x => x.Name == "server_id")
                     .Value;
                 
-                MessageId = db.PersistentData
+                InfoRoleManagerMessageId = db.PersistentData
                     .First(x => x.Name == "rolemanager_message_id")
                     .Value;
 
@@ -214,6 +203,15 @@ namespace OnePlusBot.Base
                     .First(entry => entry.Name == "xp_gain_range_max")
                     .Value;
 
+                Emotes.Clear();
+                if(db.Emotes.Any())
+                {
+                    foreach(var post in db.Emotes)
+                    {
+                      Emotes.Add(post.Key, post);
+                    }
+                }
+
                 StarboardPosts.Clear();
                 if(db.StarboardMessages.Any())
                 {
@@ -252,17 +250,18 @@ namespace OnePlusBot.Base
         }
 
         public static class OnePlusEmote {
-            public static IEmote SUCCESS = Emote.Parse("<:success:499567039451758603>");
+            public static string SUCCESS = "SUCCESS";
             public static IEmote FAIL = new Emoji("⚠");
-            public static IEmote OP_YES =  Emote.Parse("<:OPYes:426070836269678614>");
-            public static IEmote OP_NO = Emote.Parse("<:OPNo:426072515094380555>");
+            public static string OP_YES =  "OP_YES";
+            public static string OP_NO = "OP_NO";
 
             public static IEmote STAR = new Emoji("⭐");
             public static IEmote LVL_2_STAR = new Emoji("🌟");
 
             public static IEmote LVL_3_STAR = new Emoji("💫");
 
-            public static Emote LVL_4_STAR = Emote.Parse("<a:star4:640631410054529055>");
+            public static string LVL_4_STAR = "LVL_4_STAR";
+
         }
 
         public static DiscordSocketClient Bot { get; set;}

--- a/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
+++ b/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
@@ -24,12 +24,12 @@ namespace OnePlusBot.Base
                 var profanity = db.Profanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault();
                 if(profanity != null)
                 {
-                    if(reaction.Emote.Name == Global.OnePlusEmote.OP_NO.Name)
+                    if(reaction.Emote.Name == Global.Emotes[Global.OnePlusEmote.OP_NO].GetAsEmote().Name)
                     {
                         profanity.Valid = false;
                         emoteMatched = true;
                     }
-                    else if(reaction.Emote.Name == Global.OnePlusEmote.OP_YES.Name)
+                    else if(reaction.Emote.Name == Global.Emotes[Global.OnePlusEmote.OP_YES].GetAsEmote().Name)
                     {
                         profanity.Valid = true;
                         emoteMatched = true;

--- a/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
+++ b/src/OnePlusBot/Base/ProfanityReportReactionAdded.cs
@@ -11,10 +11,26 @@ namespace OnePlusBot.Base
 {
     public class ProfanityReportReactionAdded : IReactionAction
     {
+        /// <summary>
+        /// Checks wheter or not the added reaction should be handled by this action
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the profanity report at which the reaction was added</param>
+        /// <param name="channel">The <see cref="Discord.WebSocket.ISocketMessageChannel"> channel in which the profanity was reported to</param>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> object containing the added reaction</param>
+        /// <returns>boolean whether or not this action should be executed</returns>
         public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
         {
             return Global.ReportedProfanities.Where(prof => prof.MessageId == message.Id).FirstOrDefault() != null;
         }
+        
+        /// <summary>
+        /// Updates the state of the given profanity report in the database as either valid or not valid, dependingn on which reaction was added
+        /// After this is executed once for a given message, it deletes the entry from the global profanity reports list
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the profanity report at which the reaction was added</param>
+        /// <param name="channel">The <see cref="Discord.WebSocket.ISocketMessageChannel"> channel in which the profanity was reported to</param>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> object containing the added reaction</param>
+        /// <returns></returns>
         public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
         {
             var emoteMatched = false;

--- a/src/OnePlusBot/Base/RoleReactionAction.cs
+++ b/src/OnePlusBot/Base/RoleReactionAction.cs
@@ -12,10 +12,25 @@ namespace OnePlusBot.Base
 {
     public class RemoveRoleReactionAction : IReactionAction
     {
+        /// <summary>
+        /// Checks wheter or not the added reaction should be handled by this action
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the info message reponsible for handling the info post</param>
+        /// <param name="channel">The <see cref="Discord.WebSocket.ISocketMessageChannel"> info context channel</param>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> object containing the added reaction</param>
+        /// <returns>boolean whether or not this action should be executed</returns>
         public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
         {
             return reaction.MessageId == Global.InfoRoleManagerMessageId;
         }
+
+        /// <summary>
+        /// Removes the mapped role from the user reacting to the message in info (devices/helper/news)
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the info message reponsible for handling the info post</param>
+        /// <param name="channel">The <see cref="Discord.WebSocket.ISocketMessageChannel"> info context channel</param>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> object containing the added reaction</param>
+        /// <returns>Task</returns>
         public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
         {
             if(!(channel is IGuildChannel))
@@ -50,10 +65,25 @@ namespace OnePlusBot.Base
 
     public class AddRoleReactionAction : IReactionAction
     {
+        /// <summary>
+        /// Checks wheter or not the added reaction should be handled by this action
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the info message reponsible for handling the info post</param>
+        /// <param name="channel">The <see cref="Discord.WebSocket.ISocketMessageChannel"> info context channel</param>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> object containing the added reaction</param>
+        /// <returns>boolean whether or not this action should be executed</returns>
         public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
         {
             return reaction.MessageId == Global.InfoRoleManagerMessageId;
         }
+
+        /// <summary>
+        /// Gives the user reacting to the message in info the mapped role (devices/helper/news)
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the info message reponsible for handling the info post</param>
+        /// <param name="channel">The <see cref="Discord.WebSocket.ISocketMessageChannel"> info context channel</param>
+        /// <param name="reaction">The <see cref="Discord.WebSocket.SocketReaction"> object containing the added reaction</param>
+        /// <returns>task</returns>
         public async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
         {
             if(!(channel is IGuildChannel))

--- a/src/OnePlusBot/Base/SelfAssignabeRolesManager.cs
+++ b/src/OnePlusBot/Base/SelfAssignabeRolesManager.cs
@@ -10,8 +10,13 @@ namespace OnePlusBot.Base
 {
   public class SelfAssignabeRolesManager 
   {
-    public async Task SetupInfoPost(){
-      var infoChannelId = Global.Channels[Channel.INFO];
+    /// <summary>
+    /// Creates the post containing the fields for the different roles, reacts with the proper reactions to the post and deletes the old post.
+    /// </summary>
+    /// <returns>Task</returns>
+    public async Task SetupInfoPost()
+    {
+      var infoChannelId = Global.PostTargets[PostTarget.INFO];
       var guild = Global.Bot.GetGuild(Global.ServerID);
    
       var embedBuilder = new EmbedBuilder();
@@ -41,6 +46,7 @@ namespace OnePlusBot.Base
         }
         var message = await infoChannel.SendMessageAsync(embed: embedBuilder.Build());
         Global.InfoRoleManagerMessageId = message.Id;
+        // TODO refactor
         db.PersistentData.Where(dt => dt.Name == "rolemanager_message_id").First().Value = message.Id;
         await message.AddReactionsAsync(reactions.ToArray());
         db.SaveChanges();

--- a/src/OnePlusBot/Base/SelfAssignabeRolesManager.cs
+++ b/src/OnePlusBot/Base/SelfAssignabeRolesManager.cs
@@ -1,0 +1,49 @@
+using System.Threading.Tasks;
+using OnePlusBot.Data.Models;
+using Discord;
+using OnePlusBot.Data;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using System.Collections.Generic;
+   
+namespace OnePlusBot.Base
+{
+  public class SelfAssignabeRolesManager {
+    public async Task SetupInfoPost(){
+      var infoChannelId = Global.Channels[Channel.INFO];
+      var guild = Global.Bot.GetGuild(Global.ServerID);
+   
+      var embedBuilder = new EmbedBuilder();
+      embedBuilder.WithTitle("__Assignable Roles__");
+      embedBuilder.WithColor(15258703);
+      embedBuilder.WithDescription("You can assign yourself one of the following roles by reacting to its corresponding emote. \n Removing your reaction will remove your role.");
+      embedBuilder.WithFooter(new EmbedFooterBuilder().WithText("For any problems, contact Rithari#0001."));
+
+      using(var db = new Database())
+      {
+        var roles = db.ReactionRoles.Include(ro => ro.EmoteReference).Include(ro => ro.RoleReference).Where(ro => ro.Area == "info").ToList();
+        var reactions = new List<IEmote>();
+        foreach(var role in roles)
+        {
+          var roleInGuild = guild.GetRole(role.RoleReference.RoleID);
+          var emote = role.EmoteReference.GetAsEmote();
+          embedBuilder.AddField(emote + " " + roleInGuild.Name, "\u200B", true);
+          reactions.Add(emote);
+        }
+      
+        var oldPostId = Global.InfoRoleManagerMessageId;
+        var infoChannel = guild.GetTextChannel(infoChannelId);
+        var oldMeessage = await infoChannel.GetMessageAsync(oldPostId);
+        if(oldMeessage != null) 
+        {
+          await oldMeessage.DeleteAsync();
+        }
+        var message = await infoChannel.SendMessageAsync(embed: embedBuilder.Build());
+        Global.InfoRoleManagerMessageId = message.Id;
+        db.PersistentData.Where(dt => dt.Name == "rolemanager_message_id").First().Value = message.Id;
+        await message.AddReactionsAsync(reactions.ToArray());
+        db.SaveChanges();
+      }
+    }
+  }
+}

--- a/src/OnePlusBot/Base/SelfAssignabeRolesManager.cs
+++ b/src/OnePlusBot/Base/SelfAssignabeRolesManager.cs
@@ -8,7 +8,8 @@ using System.Collections.Generic;
    
 namespace OnePlusBot.Base
 {
-  public class SelfAssignabeRolesManager {
+  public class SelfAssignabeRolesManager 
+  {
     public async Task SetupInfoPost(){
       var infoChannelId = Global.Channels[Channel.INFO];
       var guild = Global.Bot.GetGuild(Global.ServerID);

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -21,7 +21,7 @@ namespace OnePlusBot.Base
         protected bool RelationAdded = false;
         public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
         {
-            return reaction.Emote.Equals(Global.OnePlusEmote.STAR) && message.Author.Id != reaction.UserId;
+            return reaction.Emote.Equals(Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote()) && message.Author.Id != reaction.UserId;
         }
         public virtual async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
         {
@@ -129,25 +129,25 @@ namespace OnePlusBot.Base
 
         private string GetStarboardMessage(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> reactionInfo, IReaction reaction, int starCount)
         {
-            var emote = Global.OnePlusEmote.STAR.Name;
+            var emote = Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote();
             if(starCount >= (int) Global.Level2Stars)
             {
-                emote = Global.OnePlusEmote.LVL_2_STAR.Name;
+                emote = Global.Emotes[Global.OnePlusEmote.LVL_2_STAR].GetAsEmote();
             }
             if(starCount >= (int) Global.Level3Stars)
             {
-                emote = Global.OnePlusEmote.LVL_3_STAR.Name;
+                emote = Global.Emotes[Global.OnePlusEmote.LVL_3_STAR].GetAsEmote();
             }
             if(starCount >= (int) Global.Level4Stars)
             {
-                emote = Global.OnePlusEmote.LVL_4_STAR.ToString();
+                emote = Global.Emotes[Global.OnePlusEmote.LVL_4_STAR].GetAsEmote();
             }
             return $"{emote} {starCount} <#{message.Channel.Id}> ID: {message.Id}"; 
         }
 
         private async Task<int> GetTrueStarCount(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> starReaction)
         {
-            var reactions = message.GetReactionUsersAsync(Global.OnePlusEmote.STAR, starReaction.Value.ReactionCount);
+            var reactions = message.GetReactionUsersAsync(Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote(), starReaction.Value.ReactionCount);
             var validReactions = 0;
             await reactions.ForEachAsync(collection =>
             {
@@ -174,7 +174,7 @@ namespace OnePlusBot.Base
                 if(this.TriggeredThreshold)
                 {
                     var currentStarReaction = message.Reactions.Where(re => re.Key.Name == reaction.Emote.Name).DefaultIfEmpty().First();
-                    var reactions = message.GetReactionUsersAsync(Global.OnePlusEmote.STAR, currentStarReaction.Value.ReactionCount);
+                    var reactions = message.GetReactionUsersAsync(Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote(), currentStarReaction.Value.ReactionCount);
                     await reactions.ForEachAsync(collection =>
                     {
                         foreach(var user in collection)

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -127,6 +127,14 @@ namespace OnePlusBot.Base
             return builder.Build();
         }
 
+        /// <summary>
+        /// Builds the message of a starboard message containing the messageID, the channel of th epost, the star count and an emote.
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="reactionInfo"></param>
+        /// <param name="reaction"></param>
+        /// <param name="starCount"></param>
+        /// <returns></returns>
         private string GetStarboardMessage(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> reactionInfo, IReaction reaction, int starCount)
         {
             var emote = Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote();
@@ -145,6 +153,12 @@ namespace OnePlusBot.Base
             return $"{emote} {starCount} <#{message.Channel.Id}> ID: {message.Id}"; 
         }
 
+        /// <summary>
+        /// Returns the actual star count on a message (the count of star reactions without the author)
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object to get the star count for</param>
+        /// <param name="starReaction">The pair of the reaction with the reaction metadata of the current reaction which was just added</param>
+        /// <returns>The amount of reactions besides the original author of the message</returns>
         private async Task<int> GetTrueStarCount(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> starReaction)
         {
             var reactions = message.GetReactionUsersAsync(Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote(), starReaction.Value.ReactionCount);

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -52,6 +52,10 @@ namespace OnePlusBot.Data
 
         public DbSet<ChannelInGroup> ChannelGroupMembers { get; set; }
 
+        public DbSet<StoredEmote> Emotes { get; set; }
+
+        public DbSet<ReactionRole> ReactionRoles { get; set; }
+
         // TODO needs to be replaced with proper dependency injection
         [Obsolete]
         public static readonly LoggerFactory LoggerFactory
@@ -91,6 +95,7 @@ namespace OnePlusBot.Data
             modelBuilder.Entity<ThreadSubscriber>().HasKey(c => new { c.UserId, c.ModMailThreadId });
             modelBuilder.Entity<ThreadMessage>().HasKey(c => new { c.ChannelId, c.ChannelMessageId });
             modelBuilder.Entity<ChannelInGroup>().HasKey(c => new {c.ChannelId, c.ChannelGroupId});
+            modelBuilder.Entity<ReactionRole>().HasKey(c => new {c.EmoteId, c.RoleID});
             modelBuilder.Entity<PostTarget>().HasIndex(p => p.Name).IsUnique();
         }
 

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -38,6 +38,8 @@ namespace OnePlusBot.Data.Models
         public static readonly string WARN_LOG = "warnlog";
         public static readonly string LEAVE_LOG = "leavelog";
 
+        public static readonly string INFO = "info";
+
         public static readonly List<string> POST_TARGETS = 
                               new List<string> { 
                                 OFFTOPIC, JOIN_LOG, BAN_LOG, 
@@ -45,7 +47,8 @@ namespace OnePlusBot.Data.Models
                                 MODMAIL_LOG, MODMAIL_NOTIFICATION, 
                                 MUTE_LOG, NEWS, PROFANITY_QUEUE, 
                                 STARBOARD, UNBAN_LOG, SUGGESTIONS, 
-                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG
+                                USERNAME_QUEUE, WARN_LOG, LEAVE_LOG,
+                                INFO
                               };
       
     }

--- a/src/OnePlusBot/Data/Models/ReactionRole.cs
+++ b/src/OnePlusBot/Data/Models/ReactionRole.cs
@@ -1,0 +1,27 @@
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("ReactionRoles")]
+    public class ReactionRole
+    {
+        
+        [Column("emote_id")]
+        public uint EmoteId { get; set; }
+        
+        [Column("role_id")]
+        public ulong RoleID { get; set; }
+
+        [Column("area")]
+        public string Area { get; set; }
+
+
+        [ForeignKey("RoleID")]
+        public virtual Role RoleReference { get; set; }
+
+
+        [ForeignKey("EmoteId")]
+        public virtual StoredEmote EmoteReference { get; set; }
+
+    }
+}

--- a/src/OnePlusBot/Data/Models/ReactionRole.cs
+++ b/src/OnePlusBot/Data/Models/ReactionRole.cs
@@ -15,10 +15,8 @@ namespace OnePlusBot.Data.Models
         [Column("area")]
         public string Area { get; set; }
 
-
         [ForeignKey("RoleID")]
         public virtual Role RoleReference { get; set; }
-
 
         [ForeignKey("EmoteId")]
         public virtual StoredEmote EmoteReference { get; set; }

--- a/src/OnePlusBot/Data/Models/StoredEmote.cs
+++ b/src/OnePlusBot/Data/Models/StoredEmote.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using Discord;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("Emotes")]
+    public class StoredEmote
+    {
+       
+        [Column("id")]
+        [Key]
+        public uint ID { get; set; }
+
+        [Column("name")]
+        public string Name { get; set; }
+
+        [Column("emote_key")]
+        public string Key { get; set; }
+
+        [Column("emote_id")]
+        public ulong EmoteId { get; set; }
+
+        [Column("animated")]
+        public bool Amimated { get; set; }
+
+        [Column("custom")]
+        public bool Custom { get; set; }
+
+        public virtual ICollection<ReactionRole> EmoteReaction { get; set; }
+
+        public IEmote GetAsEmote(){
+          if(Custom){
+             var animatedPart = this.Amimated ? "a" : "";
+            return Emote.Parse($"<{animatedPart}:{Name}:{EmoteId}>");
+          }
+          else
+          {
+            return new Emoji(Name);
+          }
+        }
+
+    }
+}

--- a/src/OnePlusBot/Data/Models/StoredEmote.cs
+++ b/src/OnePlusBot/Data/Models/StoredEmote.cs
@@ -32,8 +32,10 @@ namespace OnePlusBot.Data.Models
 
         public virtual ICollection<ReactionRole> EmoteReaction { get; set; }
 
-        public IEmote GetAsEmote(){
-          if(Custom){
+        public IEmote GetAsEmote()
+        {
+          if(Custom)
+          {
              var animatedPart = this.Amimated ? "a" : "";
             return Emote.Parse($"<{animatedPart}:{Name}:{EmoteId}>");
           }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -669,6 +669,18 @@ namespace OnePlusBot.Modules
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }
+
+        [
+            Command("setupInfoPost"),
+            Summary("Sets up the info post to let user self assign the roles"),
+            RequireRole(new string[]{"admin", "founder"})
+        ]
+        public async Task<RuntimeResult> SetupInfoPost()
+        {
+            await new SelfAssignabeRolesManager().SetupInfoPost();
+            await Task.CompletedTask;
+            return CustomResult.FromSuccess();
+        }
         
     }
 }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -686,6 +686,10 @@ namespace OnePlusBot.Modules
         }
 
 
+        /// <summary>
+        /// Creates the post in info responsible for managing the roles
+        /// </summary>
+        /// <returns>Task</returns>
         [
             Command("setupInfoPost"),
             Summary("Sets up the info post to let user self assign the roles"),

--- a/src/OnePlusBot/Modules/Fun.cs
+++ b/src/OnePlusBot/Modules/Fun.cs
@@ -140,7 +140,7 @@ namespace OnePlusBot.Modules
         ]
         public async Task<RuntimeResult> SteampAsync([Remainder] string user)
         {
-            await Context.Message.AddReactionAsync(Global.OnePlusEmote.SUCCESS);
+            await Context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.SUCCESS].GetAsEmote());
 
             var request = (HttpWebRequest) WebRequest.Create(string.Format(BadgeUrl, user));
             

--- a/src/OnePlusBot/Modules/Fun.cs
+++ b/src/OnePlusBot/Modules/Fun.cs
@@ -240,7 +240,7 @@ namespace OnePlusBot.Modules
                 stringBuilder.Append(" - ");
                 stringBuilder.Append(element.Value);
                 stringBuilder.Append(" ");
-                stringBuilder.Append(Global.OnePlusEmote.STAR);
+                stringBuilder.Append(Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote());
                 stringBuilder.Append(" ");
                 stringBuilder.Append(userReference);
                 stringBuilder.Append(Environment.NewLine);
@@ -263,7 +263,7 @@ namespace OnePlusBot.Modules
                 stringBuilder.Append(" - ");
                 stringBuilder.Append(element.Starcount);
                 stringBuilder.Append(" ");
-                stringBuilder.Append(Global.OnePlusEmote.STAR);
+                stringBuilder.Append(Global.Emotes[Global.OnePlusEmote.STAR].GetAsEmote());
                 stringBuilder.Append(" ");
                 stringBuilder.Append(Extensions.GetMessageUrl(Global.ServerID, starBoardChannelId, element.StarboardMessageId, "Jump!"));
                 stringBuilder.Append(Environment.NewLine);

--- a/src/OnePlusBot/Modules/Owner.cs
+++ b/src/OnePlusBot/Modules/Owner.cs
@@ -23,7 +23,7 @@ namespace OnePlusBot.Modules
         ]
         public async Task ShutdownAsync()
         {
-            await Context.Message.AddReactionAsync(Global.OnePlusEmote.SUCCESS);
+            await Context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.SUCCESS].GetAsEmote());
             Environment.Exit(0);
         }
 
@@ -62,7 +62,7 @@ namespace OnePlusBot.Modules
                         await sql.ExecuteNonQueryAsync();
                     }
                 }
-                await Context.Message.AddReactionAsync(Global.OnePlusEmote.SUCCESS);
+                await Context.Message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.SUCCESS].GetAsEmote());
             }
             catch
             {

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -151,8 +151,8 @@ namespace OnePlusBot.Modules
 
             await oldmessage.AddReactionsAsync(new IEmote[]
             {
-                Global.OnePlusEmote.OP_YES, 
-                Global.OnePlusEmote.OP_NO
+              Global.Emotes[Global.OnePlusEmote.OP_NO].GetAsEmote(), 
+              Global.Emotes[Global.OnePlusEmote.OP_YES].GetAsEmote()
             });
             
             await Context.Message.DeleteAsync();


### PR DESCRIPTION
With this PR the emotes are moved to the database, and are loaded via an EMOTE_KEY.
This PR also changes the the way the self assignable roles work:
Its now a command, which posts the post towards the info PostTarget and directly adds the necessary reactions.
The reactions are also printed in the description (as fields).
The reactions available this way are in the table RoleReactions with the area 'info'.