### PR TITLE
Added setnickname command

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -431,7 +431,7 @@ CREATE TABLE `Emotes` (
 -- Table structure for table `ReactionRoles`
 --
 
-DROP TABLE IF EXISTS `Emotes`;
+DROP TABLE IF EXISTS `ReactionRoles`;
 CREATE TABLE `ReactionRoles` (
  `emote_id` int(10) unsigned NOT NULL,
  `role_id` bigint(20) unsigned NOT NULL,

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -749,6 +749,25 @@ namespace OnePlusBot.Modules
             await Task.CompletedTask;
             return CustomResult.FromSuccess();
         }
+
+        /// <summary>
+        /// Changes the nickname of a user on the server (newNickname is optional, if not provided, will reset the nickname)
+        /// </summary>
+        /// <param name="user">The <see cref="Discord.IGuildUser"> object to change the nickname for</param>
+        /// <param name="newNickname">The new nickname, optional, if not provided, it will reset the nickname</param>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
+        [
+            Command("setNickname"),
+            Summary("Changes the nickname of a given user, resets if empty"),
+            RequireRole("staff"),
+            CommandDisabledCheck
+        ]
+        public async Task<RuntimeResult> SetNicknameTo(IGuildUser user, [Optional]string newNickname)
+        {
+          await user.ModifyAsync((user) => user.Nickname = newNickname);
+          return CustomResult.FromSuccess();
+        }
+
         
     }
 }


### PR DESCRIPTION
This PR adds a `setnickname` command capable of setting/resetting the nickname of a guild member.