### PR TITLE
Added functionaliy to automatically detect message links and post embeds

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -22,7 +22,7 @@ namespace OnePlusBot.Base
         private readonly CommandService _commands;
         private readonly IServiceProvider _services;
 
-        private static Regex messageRegex = new Regex("https://(canary.){0,1}discordapp.com/channels/(\\d+)/(\\d+)/(\\d+)", RegexOptions.Singleline | RegexOptions.Compiled);
+        private static Regex messageRegex = new Regex("https://(?:canary.)?discordapp.com/channels/(\\d+)/(\\d+)/(\\d+)", RegexOptions.Singleline | RegexOptions.Compiled);
 
         public CommandHandler(DiscordSocketClient bot, CommandService commands, IServiceProvider services)
         {
@@ -800,9 +800,9 @@ namespace OnePlusBot.Base
               var bot = Global.Bot;
               foreach(Match match in matches)
               {
-                var serverId = Convert.ToUInt64(match.Groups[2].Value);
-                var channelId = Convert.ToUInt64(match.Groups[3].Value);
-                var messageId = Convert.ToUInt64(match.Groups[4].Value);
+                var serverId = Convert.ToUInt64(match.Groups[1].Value);
+                var channelId = Convert.ToUInt64(match.Groups[2].Value);
+                var messageId = Convert.ToUInt64(match.Groups[3].Value);
                 var server = bot.GetGuild(serverId);
                 if(server != null)
                 {

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -22,7 +22,7 @@ namespace OnePlusBot.Base
         private readonly CommandService _commands;
         private readonly IServiceProvider _services;
 
-        private static Regex messageRegex = new Regex("https://(?:canary.)?discordapp.com/channels/(\\d+)/(\\d+)/(\\d+)", RegexOptions.Singleline | RegexOptions.Compiled);
+        private static Regex messageRegex = new Regex("https://(?:(?:canary|ptb).)?discordapp.com/channels/(\\d+)/(\\d+)/(\\d+)", RegexOptions.Singleline | RegexOptions.Compiled);
 
         public CommandHandler(DiscordSocketClient bot, CommandService commands, IServiceProvider services)
         {

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -1,9 +1,6 @@
-using System.Runtime.ConstrainedExecution;
-using System.Runtime.CompilerServices;
-using System.Data.Common;
+using OnePlusBot.Helpers;
 using System;
 using Discord;
-using Discord.Commands;
 using Discord.WebSocket;
 using System.Threading.Tasks;
 using System.Collections.Generic;
@@ -81,7 +78,7 @@ namespace OnePlusBot.Base
                 if(starCount >= (int) Global.StarboardStars)
                 {
                     var starboardMessage = await starboardChannel.SendMessageAsync(GetStarboardMessage(message, currentStarReaction, reaction, starCount), 
-                    embed: GetStarboardEmbed(message, currentStarReaction));
+                    embed: GetStarboardEmbed(message));
                     using (var db = new Database())
                     {
                         var starboardMessageDto = new StarboardMessage();
@@ -104,26 +101,15 @@ namespace OnePlusBot.Base
             }
         }
 
-        private Embed GetStarboardEmbed(IUserMessage message, KeyValuePair<IEmote, ReactionMetadata> reactionInfo)
+        /// <summary>
+        /// Creates an embed containing the starred message and a field containing al link to the starred message
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IUserMessage"> object containing the message which is getting starred.</param>
+        /// <returns>The rendered embed containing the desired info</returns>
+        private Embed GetStarboardEmbed(IUserMessage message)
         {
-            var builder =  new EmbedBuilder()
-                .WithColor(9896005)
-                .WithAuthor(author => author
-                    .WithIconUrl(message.Author.GetAvatarUrl())
-                    .WithName(message.Author.Username)
-                    )
-                    
-                .WithDescription(message.Content)
-                .AddField(fb => fb
-                    .WithName("Original")
-                    .WithValue(OnePlusBot.Helpers.Extensions.GetMessageUrl(Global.ServerID, message.Channel.Id, message.Id, "Jump!"))
-                    )
-                .WithTimestamp(message.CreatedAt);
-            if(message.Attachments.Count > 0)
-            {
-                builder = builder.WithImageUrl(message.Attachments.First().ProxyUrl);
-            }
-
+            var builder = Extensions.GetMessageAsEmbed(message);
+            builder.AddField("Original", OnePlusBot.Helpers.Extensions.GetMessageUrl(Global.ServerID, message.Channel.Id, message.Id, "Jump!"));
             return builder.Build();
         }
 

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -103,7 +103,7 @@ namespace OnePlusBot.Helpers
         public static EmbedBuilder GetMessageAsEmbed(IMessage message)
         {
           var builder = new EmbedBuilder();
-          builder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username));
+          builder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username + '#' + message.Author.Discriminator));
           var stringBuilder = new StringBuilder();
           stringBuilder.Append(message.Content);
           if(message.Attachments.Count() > 0)

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -5,6 +5,7 @@ using System.Threading.Tasks;
 using Discord;
 using OnePlusBot.Base;
 using OnePlusBot.Data.Models;
+using System.Collections.ObjectModel;
 using System.Text.RegularExpressions;
 
 namespace OnePlusBot.Helpers
@@ -69,15 +70,18 @@ namespace OnePlusBot.Helpers
             return FormatUserName(user) + " (" + user?.Id +  ")";
         }
 
-        public static String FormatMentionDetailed(IUser user){
+        public static String FormatMentionDetailed(IUser user)
+        {
             return user?.Mention + " " + FormatUserNameDetailed(user);
         }
 
-        public static Channel GetChannelById(ulong channelId){
+        public static Channel GetChannelById(ulong channelId)
+        {
             return Global.FullChannels.Where(chan => chan.ChannelID == channelId).DefaultIfEmpty(null).First();
         }
 
-        public static EmbedBuilder FaqCommandEntryToBuilder(FAQCommandChannelEntry entry) {
+        public static EmbedBuilder FaqCommandEntryToBuilder(FAQCommandChannelEntry entry) 
+        {
             var faqEmbedEntry = new EmbedBuilder();
             faqEmbedEntry.WithColor(new Color(entry.HexColor));
             faqEmbedEntry.WithDescription(entry.Text);
@@ -88,6 +92,50 @@ namespace OnePlusBot.Helpers
             faqEmbedEntry.WithAuthor(entry.Author, entry.AuthorAvatarUrl);
 
             return faqEmbedEntry;
+        }
+
+        /// <summary>
+        /// Creates an embed builder which is the best estimation at how the message can be represented as an ambed.
+        /// Contains *one* attachment, if the message contained more, containst a simplified version of an embed, if a message with an ambed is linked
+        /// </summary>
+        /// <param name="message">The <see cref="Discord.IMessage"> object representing the message to built an embed out of</param>
+        /// <returns>An <see cref="Discord.EmbedBuilder"> object representing the given message</returns>
+        public static EmbedBuilder GetMessageAsEmbed(IMessage message)
+        {
+          var builder = new EmbedBuilder();
+          builder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(message.Author.GetAvatarUrl()).WithName(message.Author.Username));
+          var stringBuilder = new StringBuilder();
+          stringBuilder.Append(message.Content);
+          if(message.Attachments.Count() > 0)
+          {
+            builder.WithImageUrl(message.Attachments.First().ProxyUrl);
+          }
+          if(message.Embeds.Count() > 0)
+          {
+            // TODO needs refactoring, because of max description length (for example help embeds.... ), should be done when adding a mechanism for all of the embeds in in the whole bot
+            foreach(var embed in message.Embeds)
+            {
+              // only support rich emebds for now
+              if(embed.Type != EmbedType.Rich) 
+              {
+                continue; 
+              }
+
+              stringBuilder.Append($" Embed \n");
+              if(embed.Title != string.Empty && embed.Title != null)
+              {
+                stringBuilder.Append($"**{embed.Title}** \n");
+              }
+              stringBuilder.Append($"{embed.Description} \n");
+              foreach(var field in embed.Fields)
+              {
+                stringBuilder.Append($" *{field.Name}*: {field.Value} \n");
+              }
+            }
+          }
+          builder.WithDescription(stringBuilder.ToString());
+          builder.WithTimestamp(message.Timestamp);
+          return builder;
         }
 
         private static string DiscordChannelUrl = "https://discordapp.com/channels/{0}/{1}";

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -425,8 +425,8 @@ namespace OnePlusBot.Modules
                     var rank = db.Users.OrderByDescending(us => us.XP).ToList().IndexOf(userInDb) + 1;
                     var nextLevel = db.ExperienceLevels.Where(lv => lv.Level == userInDb.Level + 1).FirstOrDefault();
                     embedBuilder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(userToUse.GetAvatarUrl()).WithName(userToUse.Username));
-                    embedBuilder.AddField("Current XP", userInDb.XP, true);
-                    embedBuilder.AddField("Current Level", userInDb.Level, true);
+                    embedBuilder.AddField("XP", userInDb.XP, true);
+                    embedBuilder.AddField("Level", userInDb.Level, true);
                     embedBuilder.AddField("Messages", userInDb.MessageCount, true);
                     if(nextLevel != null)
                     {


### PR DESCRIPTION
This works by checking if the message contains a direct link to a message. In case such a link is found this message is downloaded and the content of this message is displayed as an embed in the same channel.
This supports one attachment and other embeds, but only rich embeds.
There exist a lot of limitations, which are not covered with this implementation. These should be covered in a future improvement to improve the general handling on how to post embeds (and stay within the limitations).