### PR TITLE
added reminders command

### DIFF
--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -564,7 +564,8 @@ namespace OnePlusBot.Modules
               var count = 0;
               foreach(var reminder in activeReminders)
               {
-                currentEmbedBuilder.AddField($"Reminder {reminder.ID}", reminder.RemindText + $" { reminder.ReminderDate:dd.MM.yyyy HH:mm}" , true);
+                var reminderLink = Extensions.GetMessageUrl(Global.ServerID, reminder.ChannelId, reminder.MessageId, $"**{ reminder.ReminderDate:dd.MM.yyyy HH:mm}**");
+                currentEmbedBuilder.AddField($"Reminder {reminder.ID}", reminderLink + " with: " + reminder.RemindText, true);
                 count++;
                 if(((count % EmbedBuilder.MaxFieldCount) == 0) && reminder != activeReminders.Last())
                 {

--- a/src/OnePlusBot/Modules/Utility.cs
+++ b/src/OnePlusBot/Modules/Utility.cs
@@ -564,7 +564,7 @@ namespace OnePlusBot.Modules
               var count = 0;
               foreach(var reminder in activeReminders)
               {
-                currentEmbedBuilder.AddField($"Reminder {count + 1}", reminder.RemindText + $" { reminder.ReminderDate:dd.MM.yyyy HH:mm}" , true);
+                currentEmbedBuilder.AddField($"Reminder {reminder.ID}", reminder.RemindText + $" { reminder.ReminderDate:dd.MM.yyyy HH:mm}" , true);
                 count++;
                 if(((count % EmbedBuilder.MaxFieldCount) == 0) && reminder != activeReminders.Last())
                 {


### PR DESCRIPTION
This PR adds a command for the users to check the currently active reminders (they have not happened yet). The command shows the text the user wands to be reminded of, and the date at which it happens (In bot timezone)