### PR TITLE
Added the feature to directly open up a modmail thread via reaction on a username notification

### DIFF
--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -122,6 +122,7 @@ namespace OnePlusBot.Base
             AddReactionActions.Add(new AddRoleReactionAction());
             AddReactionActions.Add(new StarboardAddedReactionAction());
             AddReactionActions.Add(new ProfanityReportReactionAdded());
+            AddReactionActions.Add(new UserNameReportReactionAction());
             RemoveReactionActions.Add(new RemoveRoleReactionAction());
             RemoveReactionActions.Add(new StarboardRemovedReactionAction());
         }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -187,7 +187,9 @@ namespace OnePlusBot.Base
         {
           var embed = GetUserNameNotificationEmbed(embedTitle, beforeText, afterText, user);
           var userlog = guild.GetTextChannel(Global.PostTargets[PostTarget.USERNAME_QUEUE]);
-          await userlog.SendMessageAsync(embed: embed);
+          var message = await userlog.SendMessageAsync(embed: embed);
+          await message.AddReactionAsync(Global.Emotes[Global.OnePlusEmote.OPEN_MODMAIL].GetAsEmote());
+          Global.UserNameNotifications.Add(message.Id, user.Id);
         }
 
         private async Task OnUserLeft(SocketGuildUser socketGuildUser)

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -60,6 +60,8 @@ namespace OnePlusBot.Base
         public static int XPGainRangeMin { get; set; }
 
         public static int XPGainRangeMax { get; set; }
+
+        public static Dictionary<ulong, ulong> UserNameNotifications { get; set; }
         
         public static string Token
         {
@@ -110,6 +112,7 @@ namespace OnePlusBot.Base
             RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
             Emotes = new Dictionary<string, StoredEmote>();
             Commands = new  List<Command>();
+            UserNameNotifications = new Dictionary<ulong, ulong>();
             LoadGlobal();
         }
 
@@ -272,6 +275,8 @@ namespace OnePlusBot.Base
             public static string LVL_3_STAR = "LVL_3_STAR";
 
             public static string LVL_4_STAR = "LVL_4_STAR";
+
+            public static string OPEN_MODMAIL = "OPEN_MODMAIL";
 
         }
 

--- a/src/OnePlusBot/Base/UserNameReportReactionAction.cs
+++ b/src/OnePlusBot/Base/UserNameReportReactionAction.cs
@@ -1,0 +1,39 @@
+using OnePlusBot.Helpers;
+using System;
+using Discord;
+using Discord.WebSocket;
+using System.Threading.Tasks;
+using System.Collections.Generic;
+using System.Linq;
+using OnePlusBot.Data;
+using OnePlusBot.Data.Models;
+
+namespace OnePlusBot.Base
+{
+    public class UserNameReportReactionAction : IReactionAction
+    {
+
+        /// <summary>
+        /// Only execute the action in case the emote is the post box and when the element is found in the global list of nickname notifications
+        /// </summary>
+        /// <returns></returns>
+        public Boolean ActionApplies(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction)
+        {
+            return Global.UserNameNotifications.Where(n => n.Key == message.Id).Any() && 
+            reaction.Emote.Name == Global.Emotes[Global.OnePlusEmote.OPEN_MODMAIL].GetAsEmote().Name;
+        }
+
+        /// <summary>
+        /// Opens a modmail thread for the given user causing this nickname notification
+        /// </summary>
+        /// <returns>Task</returns>
+        public virtual async Task Execute(IUserMessage message, ISocketMessageChannel channel, SocketReaction reaction) 
+        {
+          var entry = Global.UserNameNotifications.Where(n => n.Key == message.Id).First();
+          var guild = Global.Bot.GetGuild(Global.ServerID);
+          await new ModMailManager().ContactUser(guild.GetUser(entry.Value), channel);
+          Global.UserNameNotifications.Remove(entry.Key);
+        }
+    }
+
+}

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -61,8 +61,7 @@ namespace OnePlusBot.Data
         public DbSet<CommandModule> Modules { get; set; }
 
         public DbSet<CommandInChannelGroup> CommandInChannelGroups { get; set; }
-
-
+        
         // TODO needs to be replaced with proper dependency injection
         [Obsolete]
         public static readonly LoggerFactory LoggerFactory


### PR DESCRIPTION
The reaction will open up the thread and post a link in the same channel leading to the newly created channel.
If a channel was already open, this will post a message indicating so also containing a link to the channel.
The notifications are only stored at runtime, so it does not work if the bot goes down in the meantime.