### PR TITLE
added ability for staff members to provide feedback

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -754,17 +754,6 @@ namespace OnePlusBot.Base
 
         private static bool ViolatesRule(SocketMessage message)
         {
-        /*    var guildUser = message.Author as IGuildUser;
-            if (message.Channel is SocketDMChannel)
-            {
-                if (guildUser.RoleIds.Contains(Global.Roles["staff"]))
-                {
-                    var guild = Global.Bot.GetGuild(Global.ServerID);
-                    var feedbackChannel = guild.GetTextChannel(Global.Channels["feedback"]);
-                    feedbackChannel.SendMessageAsync("Feedback!" + Environment.NewLine + message.Content);
-                }
-            }*/
-
             string messageText = message.Content;
             var channelObj = Global.FullChannels.Where(ch => ch.ChannelID == message.Channel.Id).FirstOrDefault();
             bool ignoredChannel = channelObj != null && channelObj.InviteCheckExempt();
@@ -884,20 +873,33 @@ namespace OnePlusBot.Base
             {
                 return;
             }
-            var modmailThread = ModMailThreadForUserExists(message.Author);
 
-            if(modmailThread && message.Channel is IDMChannel)
+                
+            if (message.Channel is SocketDMChannel)
             {
-                await new ModMailManager().HandleModMailUserReply(message);
+                var guild = Global.Bot.GetGuild(Global.ServerID);
+                var guildUser = guild.GetUser(message.Author.Id);
+                if (guildUser != null && guildUser.Roles.Where(ro => ro.Id == Global.Roles["staff"]).Any())
+                {
+                    var feedbackChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.FEEDBACK]);
+                    await feedbackChannel.SendMessageAsync("Feedback!" + Environment.NewLine + message.Content);
+                }
+                else
+                {
+                    var modmailThread = ModMailThreadForUserExists(message.Author);
+
+                    if(modmailThread && message.Channel is IDMChannel)
+                    {
+                        await new ModMailManager().HandleModMailUserReply(message);
+                    }
+                    else if(message.Channel is IDMChannel)
+                    {
+                        await new ModMailManager().CreateModmailThread(message);
+                    }
+                }
             }
-            else if(message.Channel is IDMChannel)
-            {
-                await new ModMailManager().CreateModmailThread(message);
-            }
 
-
-
-               
+         
             var channelId = message.Channel.Id;
 
             if (channelId == Global.Channels[Channel.SETUPS])

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -42,6 +42,8 @@ namespace OnePlusBot.Data.Models
 
         public static readonly string INFO = "info";
 
+        public static readonly string FEEDBACK = "feedback";
+
         public static readonly List<string> POST_TARGETS = 
                               new List<string> { 
                                 OFFTOPIC, JOIN_LOG, BAN_LOG, 
@@ -50,7 +52,7 @@ namespace OnePlusBot.Data.Models
                                 MUTE_LOG, NEWS, PROFANITY_QUEUE, 
                                 STARBOARD, UNBAN_LOG, SUGGESTIONS, 
                                 USERNAME_QUEUE, WARN_LOG, LEAVE_LOG,
-                                INFO, PROFANITY_PROMPT
+                                INFO, PROFANITY_PROMPT, FEEDBACK
                               };
       
     }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -222,7 +222,7 @@ namespace OnePlusBot.Modules
             } 
             catch(HttpException)
             {
-                Console.WriteLine("Seems like user disabled the DMs, cannot send message about the mute.");
+              await Context.Channel.SendMessageAsync("Seems like user disabled the DMs, cannot send message about the mute.");
             }    
 
             var muteData = new Mute


### PR DESCRIPTION
In order for this to work, the posttarget 'feedback' needs to be set. Will override the ability of staff members to open modmail thread by DMing the bot.