### PR TITLE
Adder username to warnings selfcheck

### DIFF
--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -545,8 +545,10 @@ namespace OnePlusBot.Modules
                 {
                     individualWarnings = db.Warnings.Where(x => x.WarnedUserID == requestee.Id && !x.Decayed);
                     var totalWarnings = db.Warnings.Where(x => x.WarnedUserID == requestee.Id);
-
-                    await ReplyAsync($"You have {individualWarnings.Count()} active out of {totalWarnings.Count()} total warnings.");
+                    var builder = new EmbedBuilder();
+                    builder.WithAuthor(new EmbedAuthorBuilder().WithIconUrl(requestee.GetAvatarUrl()).WithName(requestee.Username + '#' + requestee.Discriminator));
+                    builder.WithDescription($"{requestee.Username + '#' + requestee.Discriminator} has {individualWarnings.Count()} active out of {totalWarnings.Count()} total warnings.");
+                    await ReplyAsync(embed: builder.Build());
 
                     return;
                 }


### PR DESCRIPTION
Users are able to check their own warnings, and because the same command for users and staff is used, this command has a user as an optional parameter for staff (in case they want to check the warnings for a user). This means that users also can use the command with a parameter, and seemingly see the warnings for the specified users, even tho the response contains their own warnings.

This PR changes the fact, that users see for which user the displayed warnings are for. 