### PR TITLE
Always download all users so bot finds them in cache

### DIFF
--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -234,7 +234,7 @@ namespace OnePlusBot.Base
         private static IServiceProvider BuildServices()
         {
             return new ServiceCollection()
-                .AddSingleton(new DiscordSocketClient(new DiscordSocketConfig {MessageCacheSize = 350 }))
+                .AddSingleton(new DiscordSocketClient(new DiscordSocketConfig {MessageCacheSize = 350, AlwaysDownloadUsers = true}))
                 .AddSingleton<InteractiveService>()
                 .AddSingleton<CommandHandler>()
                 .AddSingleton<CommandService>()


### PR DESCRIPTION
The issue existed in which certain commands (taking the direct user object as a parameter/userid) could not find specified users, because the bot did not keep those users in cache.

This PR changes the configuration that the bot always downloads all users (only recommended if the bot runs in a low amount of guilds/lower amount of users). The exact issue could not be reproduced on test servers, because the users were always in cache.