### PR TITLE
Changed regex for checking referral links to allow more country codes

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -607,7 +607,7 @@ namespace OnePlusBot.Base
                 }
             }
 
-            var matches = Regex.Matches(message.Content, @"https?:\/\/(?:www\.)?oneplus\.com[^\s]*invite(?:\#([^\s]+)|.+\=([^\s\&]+))", RegexOptions.IgnoreCase);
+            var matches = Regex.Matches(message.Content, @"https?:\/\/(?:www\.)?oneplus\.(?:[a-z]{1,63})[^\s]*invite(?:\#([^\s]+)|.+\=([^\s\&]+))", RegexOptions.IgnoreCase);
 
             if (matches.Count > 2)
             {


### PR DESCRIPTION
The existing regex had .com hardcoded for the check for a referral link. With this PR this is changed, to allow more in this section of the URL.