### PR TITLE
Added jump link to edited/deleted messages

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -355,32 +355,26 @@ namespace OnePlusBot.Base
 
                 var channel = (SocketTextChannel)socketChannel;
 
-                var embed = new EmbedBuilder
-                {
-                    Color = Color.Blue,
-                    Description = $":bulb: Message from '{author.Username}' edited in {channel.Mention}",
-                    Fields = {
-                        new EmbedFieldBuilder()
-                        {
-                            IsInline = false,
-                            Name = $"Original message: ",
-                            Value = before.Content
-                        },
-                        new EmbedFieldBuilder()
-                        {
-                            IsInline = false,
-                            Name = $"New message: ",
-                            Value = message.Content
-                        }
-                    },
-                    ThumbnailUrl = author.GetAvatarUrl(),
-                    Timestamp = DateTime.Now
-                };
+                var embed = new EmbedBuilder();
+                embed.WithDescription($":bulb: Message from '{author.Username}' edited in {channel.Mention}");
+                embed.WithColor(Color.Blue);
+                embed.WithThumbnailUrl(author.GetAvatarUrl());
+                embed.WithTimestamp(DateTime.Now);
+                embed.AddField("Original message:", before.Content);
+                embed.AddField("New message", message.Content);
+                embed.AddField("Jump link", Extensions.FormatLinkWithDisplay("Jump!", message.GetJumpUrl()));
 
                 await channel.Guild.GetTextChannel(Global.PostTargets[PostTarget.EDIT_LOG]).SendMessageAsync(embed: embed.Build());
             }
         }
 
+        /// <summary>
+        /// Reports deleted messages to the 'DELETE_LOG' post target. If the message was in the starboard channel, it marks the post 
+        /// as tdeleted for the starboard mechanism
+        /// </summary>
+        /// <param name="cacheable">Cacheable which was deleted</param>
+        /// <param name="socketChannel">The channel in which the message was deleted</param>
+        /// <returns>Task</returns>
         private async Task OnMessageRemoved(Cacheable<IMessage, ulong> cacheable, ISocketMessageChannel socketChannel)
         {
 
@@ -427,7 +421,12 @@ namespace OnePlusBot.Base
             {
                 originalMessage = cacheable.Value.Content;
             }
-            fields.Add(new EmbedFieldBuilder() { IsInline = false, Name = $":x: Original message: ", Value = originalMessage });
+            fields.Add(new EmbedFieldBuilder() { Name = ":x: Original message: ", Value = originalMessage });
+            if(deletedMessage != null) 
+            {
+              fields.Add(new EmbedFieldBuilder() { Name = "Link", Value=Extensions.FormatLinkWithDisplay("Jump!", deletedMessage.GetJumpUrl())});
+            }
+           
             if(deletedMessage != null && deletedMessage.Attachments != null){
                     // you can upload multiple attachments at once on mobile
                 var attachments = deletedMessage.Attachments.ToList();
@@ -684,7 +683,7 @@ namespace OnePlusBot.Base
             builder.AddField("User in question ", Extensions.FormatMentionDetailed(message.Author))
                 .AddField(f => {
                     f.Name = "Location of the profane message";
-                    f.Value = Extensions.GetMessageUrl(Global.ServerID, message.Channel.Id, message.Id, message.Channel.Name);
+                    f.Value = Extensions.FormatLinkWithDisplay(message.Channel.Name, message.GetJumpUrl());
                     f.IsInline = true;
                     })
                 .AddField(f => {

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -370,7 +370,7 @@ namespace OnePlusBot.Base
 
         /// <summary>
         /// Reports deleted messages to the 'DELETE_LOG' post target. If the message was in the starboard channel, it marks the post 
-        /// as tdeleted for the starboard mechanism
+        /// as deleted for the starboard mechanism
         /// </summary>
         /// <param name="cacheable">Cacheable which was deleted</param>
         /// <param name="socketChannel">The channel in which the message was deleted</param>

--- a/src/OnePlusBot/Base/StarboardReactionAction.cs
+++ b/src/OnePlusBot/Base/StarboardReactionAction.cs
@@ -109,7 +109,7 @@ namespace OnePlusBot.Base
         private Embed GetStarboardEmbed(IUserMessage message)
         {
             var builder = Extensions.GetMessageAsEmbed(message);
-            builder.AddField("Original", OnePlusBot.Helpers.Extensions.GetMessageUrl(Global.ServerID, message.Channel.Id, message.Id, "Jump!"));
+            builder.AddField("Original", OnePlusBot.Helpers.Extensions.FormatLinkWithDisplay("Jump!", message.GetJumpUrl()));
             return builder.Build();
         }
 

--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -142,18 +142,53 @@ namespace OnePlusBot.Helpers
         private static string DiscordChannelUrl = "https://discordapp.com/channels/{0}/{1}";
 
         private static string DiscordMessageUrl = DiscordChannelUrl + "/{2}";
+
+        /// <summary>
+        /// Returns a link towards the given channel in the given server with the given display text in markdown
+        /// </summary>
+        /// <param name="serverId">ServerID of the channel</param>
+        /// <param name="channelId">ChannelID of the channel</param>
+        /// <param name="displayName">value which should be used as the display text</param>
+        /// <returns>The absolute link towards the given channel in the given server in markdown with the given display text</returns>
         public static string GetChannelUrl(ulong serverId, ulong channelId, string displayName)
         {
-            return $"[{ displayName }]({string.Format(DiscordChannelUrl, serverId, channelId)})";
+            return FormatLinkWithDisplay(displayName, string.Format(DiscordChannelUrl, serverId, channelId));
         }
 
+        /// <summary>
+        /// Returns a link towards the given message in the given channel of the given server with the given display text in markdown
+        /// </summary>
+        /// <param name="serverId">ServerID of the channel</param>
+        /// <param name="channelId">ChannelID of the channel</param>
+        /// <param name="messageId">MessageID for the message</param>
+        /// <param name="displayName">value which should be used as the display text</param>
+        /// <returns>The absolute link towards the given message in the given channel of the given server in markdown with the given display text</returns>
         public static string GetMessageUrl(ulong serverId, ulong channelId, ulong messageId, string displayName)
         {
-            return $"[{ displayName }]({GetSimpleMessageUrl(serverId, channelId, messageId)})";
+            return FormatLinkWithDisplay(displayName, GetSimpleMessageUrl(serverId, channelId, messageId));
         }
 
-        public static string GetSimpleMessageUrl(ulong serverId, ulong channelId, ulong messageId){
+        /// <summary>
+        /// Returns an URL towards the given message in the given channel of the given server
+        /// </summary>
+        /// <param name="serverId">ServerID of the channel</param>
+        /// <param name="channelId">ChannelID of the channel</param>
+        /// <param name="messageId">MessageID for the message</param>
+        /// <returns>The absolute URL towards the given message in the given channel of the given server</returns>
+        public static string GetSimpleMessageUrl(ulong serverId, ulong channelId, ulong messageId)
+        {
             return $"{string.Format(DiscordMessageUrl, serverId, channelId, messageId)}";
+        }
+
+        /// <summary>
+        /// Formats the given URL with the given display text in markdown
+        /// </summary>
+        /// <param name="displayText">The text the url should have as display text</param>
+        /// <param name="url">The URL where the link leads towards</param>
+        /// <returns>The URL formatted in markdown with the given display text</returns>
+        public static string FormatLinkWithDisplay(string displayText, string url) 
+        {
+          return $"[{ displayText }]({url})";
         }
 
         public static string MakeLinkNotEmbedded(string link){

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -18,6 +18,12 @@ namespace OnePlusBot.Modules
 {
     public class Administration : ModuleBase<SocketCommandContext>
     {
+        /// <summary>
+        /// Bans the user by the given id with an optional reason.
+        /// </summary>
+        /// <param name="name">Id of the user to be banned</param>
+        /// <param name="reason">Reason for the ban (optional)</param>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("banid", RunMode = RunMode.Async),
             Summary("Bans specified user."),
@@ -41,20 +47,10 @@ namespace OnePlusBot.Modules
             var banMessage = new EmbedBuilder()
             .WithColor(9896005)
             .WithTitle("⛔️ Banned User")
-            .AddField(efb => efb
-                .WithName("UserId")
-                .WithValue(name)
-                .WithIsInline(true))
-            .AddField(efb => efb
-                .WithName("By")
-                .WithValue(Extensions.FormatUserName(Context.User))
-                .WithIsInline(true))
-            .AddField(efb => efb
-                .WithName("Reason")
-                .WithValue(reason))
-            .AddField(efb => efb
-                .WithName("Link")
-                .WithValue(Extensions.GetMessageUrl(Global.ServerID, Context.Channel.Id, Context.Message.Id, "Jump!")));
+            .AddField("UserId", name, true)
+            .AddField("By", Extensions.FormatUserName(Context.User) , true)
+            .AddField("Reason", reason)
+            .AddField("Link", Extensions.FormatLinkWithDisplay("Jump!", Context.Message.GetJumpUrl()));
 
             await banLogChannel.SendMessageAsync(embed: banMessage.Build());
 
@@ -62,6 +58,12 @@ namespace OnePlusBot.Modules
         }
     
 
+        /// <summary>
+        /// Bans the given user with the given reason (default text if none provided). Also sends a direct message to the user containing the reason and the mail used for appeals
+        /// </summary>
+        /// <param name="user"><see ref="Discord.IGuildUser"> object of the user to be banned</param>
+        /// <param name="reason">Optional reason for the ban</param>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("ban", RunMode = RunMode.Async),
             Summary("Bans specified user."),
@@ -106,20 +108,10 @@ namespace OnePlusBot.Modules
                 var banlog = new EmbedBuilder()
                 .WithColor(9896005)
                 .WithTitle("⛔️ Banned User")
-                .AddField(efb => efb
-                    .WithName("User")
-                    .WithValue(Extensions.FormatUserNameDetailed(user))
-                    .WithIsInline(true))
-                .AddField(efb => efb
-                    .WithName("By")
-                    .WithValue(Extensions.FormatUserName(Context.User))
-                    .WithIsInline(true))
-                .AddField(efb => efb
-                    .WithName("Reason")
-                    .WithValue(reason))
-                .AddField(efb => efb
-                    .WithName("Link")
-                    .WithValue(Extensions.GetMessageUrl(Global.ServerID, Context.Channel.Id, Context.Message.Id, "Jump!")));
+                .AddField("User", Extensions.FormatUserNameDetailed(user), true)
+                .AddField("By", Extensions.FormatUserName(Context.User), true)
+                .AddField("Reason", reason)
+                .AddField("Link", Extensions.FormatLinkWithDisplay("Jump!", Context.Message.GetJumpUrl()));
 
                 await banLogChannel.SendMessageAsync(embed: banlog.Build());
 


### PR DESCRIPTION
This PR adds a link to a deleted/edited message in the log message of a message.
It also fixes the handling of messageURLs at several places (We did not need to build the url, we had the message object available)