### PR TITLE
Fixed unused erroneous code regarding banId

### DIFF
--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -38,8 +38,6 @@ namespace OnePlusBot.Data.Models
         public static readonly string WARN_LOG = "warnlog";
         public static readonly string LEAVE_LOG = "leavelog";
 
-        public static readonly string PROFANITY_PROMPT = "profanityprompt";
-
         public static readonly string INFO = "info";
 
         public static readonly string FEEDBACK = "feedback";
@@ -52,7 +50,7 @@ namespace OnePlusBot.Data.Models
                                 MUTE_LOG, NEWS, PROFANITY_QUEUE, 
                                 STARBOARD, UNBAN_LOG, SUGGESTIONS, 
                                 USERNAME_QUEUE, WARN_LOG, LEAVE_LOG,
-                                INFO, PROFANITY_PROMPT, FEEDBACK
+                                INFO, FEEDBACK
                               };
       
     }

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -37,7 +37,6 @@ namespace OnePlusBot.Modules
                 reason = "No reason provided.";
             }
 
-            var modlog = Context.Guild.GetTextChannel(Global.Channels["banlog"]);
             var banMessage = new EmbedBuilder()
             .WithColor(9896005)
             .WithTitle("⛔️ Banned User")


### PR DESCRIPTION
Removed the retrieval of the banlog channel (this channel does not exist with this name anymore) which caused an error when trying to ban users via id.

Removed an unused posttarget.