### PR TITLE
Fix the parsing on the setnickname command.

### DIFF
--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -790,7 +790,7 @@ namespace OnePlusBot.Modules
             RequireRole("staff"),
             CommandDisabledCheck
         ]
-        public async Task<RuntimeResult> SetNicknameTo(IGuildUser user, [Optional]string newNickname)
+        public async Task<RuntimeResult> SetNicknameTo(IGuildUser user, [Remainder]string newNickname)
         {
           await user.ModifyAsync((user) => user.Nickname = newNickname);
           return CustomResult.FromSuccess();


### PR DESCRIPTION
Currently the `;setnickname` command will not work correctly if your intended change has spaces in between words. This is caused by the `Optional` parameter.  

Changing this to `Remainder` allows for a spaced nickname.