### PR TITLE
Adding userIds to various events

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -356,7 +356,7 @@ namespace OnePlusBot.Base
                 var channel = (SocketTextChannel)socketChannel;
 
                 var embed = new EmbedBuilder();
-                embed.WithDescription($":bulb: Message from '{author.Username}' edited in {channel.Mention}");
+                embed.WithDescription($":bulb: Message from '{Extensions.FormatUserNameDetailed(author)}' edited in {channel.Mention}");
                 embed.WithColor(Color.Blue);
                 embed.WithThumbnailUrl(author.GetAvatarUrl());
                 embed.WithTimestamp(DateTime.Now);
@@ -438,7 +438,7 @@ namespace OnePlusBot.Base
                 var embed = new EmbedBuilder
                 {
                     Color = Color.Blue,
-                    Description = $":bulb: Message from '{cacheable.Value.Author.Username}' removed in {channel.Mention}",
+                    Description = $":bulb: Message from '{Extensions.FormatUserNameDetailed(cacheable.Value.Author)}' removed in {channel.Mention}",
                     Fields = fields,
                     ThumbnailUrl = cacheable.Value.Author.GetAvatarUrl(),
                     Timestamp = DateTime.Now

--- a/src/OnePlusBot/Base/MuteTimerManager.cs
+++ b/src/OnePlusBot/Base/MuteTimerManager.cs
@@ -116,7 +116,7 @@ namespace OnePlusBot.Base
             noticeEmbed.Title = "User has been unmuted!";
             noticeEmbed.ThumbnailUrl = user.GetAvatarUrl();
 
-            noticeEmbed.AddField("Unmuted User", OnePlusBot.Helpers.Extensions.FormatUserName(user))
+            noticeEmbed.AddField("Unmuted User", OnePlusBot.Helpers.Extensions.FormatUserNameDetailed(user))
                         .AddField("Mute Id", muteId)
                         .AddField("Mute duration", Extensions.FormatTimeSpan(DateTime.Now - muteObj.MuteDate))
                         .AddField("Muted since", Extensions.FormatDateTime(muteObj.MuteDate));

--- a/src/OnePlusBot/Modules/Administration.cs
+++ b/src/OnePlusBot/Modules/Administration.cs
@@ -47,7 +47,7 @@ namespace OnePlusBot.Modules
             .WithColor(9896005)
             .WithTitle("⛔️ Banned User")
             .AddField("UserId", name, true)
-            .AddField("By", Extensions.FormatUserName(Context.User) , true)
+            .AddField("By", Extensions.FormatUserNameDetailed(Context.User), true)
             .AddField("Reason", reason)
             .AddField("Link", Extensions.FormatLinkWithDisplay("Jump!", Context.Message.GetJumpUrl()));
 
@@ -109,7 +109,7 @@ namespace OnePlusBot.Modules
                 .WithColor(9896005)
                 .WithTitle("⛔️ Banned User")
                 .AddField("User", Extensions.FormatUserNameDetailed(user), true)
-                .AddField("By", Extensions.FormatUserName(Context.User), true)
+                .AddField("By", Extensions.FormatUserNameDetailed(Context.User), true)
                 .AddField("Reason", reason)
                 .AddField("Link", Extensions.FormatLinkWithDisplay("Jump!", Context.Message.GetJumpUrl()));
 
@@ -245,8 +245,8 @@ namespace OnePlusBot.Modules
             builder.ThumbnailUrl = user.GetAvatarUrl();
             
             const string discordUrl = "https://discordapp.com/channels/{0}/{1}/{2}";
-            builder.AddField("Muted User", Extensions.FormatUserName(user))
-                   .AddField("Muted by", Extensions.FormatUserName(author))
+            builder.AddField("Muted User", Extensions.FormatUserNameDetailed(user))
+                   .AddField("Muted by", Extensions.FormatUserNameDetailed(author))
                    .AddField("Location of the mute",
                         $"[#{Context.Message.Channel.Name}]({string.Format(discordUrl, Context.Guild.Id, Context.Channel.Id, Context.Message.Id)})")
                    .AddField("Reason", reason ?? "No reason was provided.")


### PR DESCRIPTION
Some events only logged the Username and mostly the Discrim. This PR changes some places to also include the userId.
The events and user ids in question:
Message edited:  The author of the message
Message deleted: The author of the message
Mute: The person being muted and the person executing the mute
Automatic Unmute: The person being unmuted
Ban: The Person executing the ban (both id and direct ban)
