### PR TITLE
Adapts to new role ping permissions

### DIFF
--- a/src/OnePlusBot/Modules/Utility/Server.cs
+++ b/src/OnePlusBot/Modules/Utility/Server.cs
@@ -68,7 +68,6 @@ namespace OnePlusBot.Modules.Utility
             if (news.Contains("@everyone") || news.Contains("@here") || news.Contains("@news")) 
                 return CustomResult.FromError("Your news article contained one or more illegal pings!");
 
-            await newsRole.ModifyAsync(x => x.Mentionable = true);
             IMessage posted;
             var messageToPost = news + Environment.NewLine + Environment.NewLine + newsRole.Mention + Environment.NewLine + "- " + Context.Message.Author;
             try {
@@ -85,12 +84,6 @@ namespace OnePlusBot.Modules.Utility
                     posted = await newsChannel.SendMessageAsync(messageToPost);
                 }
             }
-            finally 
-            {
-                await newsRole.ModifyAsync(x => x.Mentionable = false);
-            }
-            
-           
 
             Global.NewsPosts[Context.Message.Id] = posted.Id;
 

--- a/src/OnePlusBot/Modules/Utility/Server.cs
+++ b/src/OnePlusBot/Modules/Utility/Server.cs
@@ -70,7 +70,6 @@ namespace OnePlusBot.Modules.Utility
 
             IMessage posted;
             var messageToPost = news + Environment.NewLine + Environment.NewLine + newsRole.Mention + Environment.NewLine + "- " + Context.Message.Author;
-            try {
                 if(needsAttachments)
                 {
                     var attachment = Context.Message.Attachments.First();
@@ -83,8 +82,7 @@ namespace OnePlusBot.Modules.Utility
                 {
                     posted = await newsChannel.SendMessageAsync(messageToPost);
                 }
-            }
-
+                
             Global.NewsPosts[Context.Message.Id] = posted.Id;
 
             return CustomResult.FromSuccess();


### PR DESCRIPTION
Fixes #258 

Removes the call that would modify the news role in order to be pingable before a news post, as Discord has changed the ways permissions work, the bot can now bypass unmentionable restrictions and ping all roles independently, eliminating the need to apply aforementioned changes to the role.