### PR TITLE
reverted role mention change

### DIFF
--- a/src/OnePlusBot/Modules/Utility/Server.cs
+++ b/src/OnePlusBot/Modules/Utility/Server.cs
@@ -68,8 +68,10 @@ namespace OnePlusBot.Modules.Utility
             if (news.Contains("@everyone") || news.Contains("@here") || news.Contains("@news")) 
                 return CustomResult.FromError("Your news article contained one or more illegal pings!");
 
+            await newsRole.ModifyAsync(x => x.Mentionable = true);
             IMessage posted;
             var messageToPost = news + Environment.NewLine + Environment.NewLine + newsRole.Mention + Environment.NewLine + "- " + Context.Message.Author;
+            try {
                 if(needsAttachments)
                 {
                     var attachment = Context.Message.Attachments.First();
@@ -82,6 +84,11 @@ namespace OnePlusBot.Modules.Utility
                 {
                     posted = await newsChannel.SendMessageAsync(messageToPost);
                 }
+            }
+            finally
+            {
+              await newsRole.ModifyAsync(x => x.Mentionable = false);
+            }
                 
             Global.NewsPosts[Context.Message.Id] = posted.Id;
 


### PR DESCRIPTION
Because the change did not apply to bots, and this broke the pings for news.