### PR TITLE
Added emote histogramm

### DIFF
--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -470,4 +470,18 @@ CREATE TABLE `ResponseTemplate` (
  UNIQUE KEY `template_key` (`template_key`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
+--
+-- Table structure for table `EmoteHeatMap`
+--
+
+CREATE TABLE `EmoteHeatMap` (
+ `id` int(8) unsigned NOT NULL AUTO_INCREMENT,
+ `emote_id` int(10) unsigned NOT NULL,
+ `usage_date` datetime DEFAULT CURRENT_TIMESTAMP,
+ `usage_count` int(8) unsigned NOT NULL,
+ PRIMARY KEY (`id`),
+ KEY `fk_emote_fk` (`emote_id`),
+ CONSTRAINT `fk_emote_fk` FOREIGN KEY (`emote_id`) REFERENCES `Emotes` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
 SET FOREIGN_KEY_CHECKS=1;

--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -425,8 +425,9 @@ CREATE TABLE `Emotes` (
  `animated` tinyint(4) NOT NULL DEFAULT '0',
  `emote_id` bigint(20) unsigned NOT NULL DEFAULT '0',
  `custom` tinyint(4) NOT NULL DEFAULT '1',
+ `tracking_disabled` tinyint(4) NOT NULL DEFAULT '1',
  PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=6 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 --
 -- Table structure for table `ReactionRoles`
@@ -474,15 +475,14 @@ CREATE TABLE `ResponseTemplate` (
 -- Table structure for table `EmoteHeatMap`
 --
 
-CREATE TABLE `Emotes` (
- `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
- `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
- `emote_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
- `animated` tinyint(4) NOT NULL DEFAULT '0',
- `emote_id` bigint(20) unsigned NOT NULL DEFAULT '0',
- `custom` tinyint(4) NOT NULL DEFAULT '1',
- `tracking_disabled` tinyint(4) NOT NULL DEFAULT '1',
- PRIMARY KEY (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `EmoteHeatMap` (
+ `id` int(8) unsigned NOT NULL AUTO_INCREMENT,
+ `emote_id` int(10) unsigned NOT NULL,
+ `usage_date` datetime DEFAULT CURRENT_TIMESTAMP,
+ `usage_count` int(8) unsigned NOT NULL,
+ PRIMARY KEY (`id`),
+ KEY `fk_emote_fk` (`emote_id`),
+ CONSTRAINT `fk_emote_fk` FOREIGN KEY (`emote_id`) REFERENCES `Emotes` (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=10 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/sql_scripts/ddl.sql
+++ b/sql_scripts/ddl.sql
@@ -474,14 +474,15 @@ CREATE TABLE `ResponseTemplate` (
 -- Table structure for table `EmoteHeatMap`
 --
 
-CREATE TABLE `EmoteHeatMap` (
- `id` int(8) unsigned NOT NULL AUTO_INCREMENT,
- `emote_id` int(10) unsigned NOT NULL,
- `usage_date` datetime DEFAULT CURRENT_TIMESTAMP,
- `usage_count` int(8) unsigned NOT NULL,
- PRIMARY KEY (`id`),
- KEY `fk_emote_fk` (`emote_id`),
- CONSTRAINT `fk_emote_fk` FOREIGN KEY (`emote_id`) REFERENCES `Emotes` (`id`)
-) ENGINE=InnoDB AUTO_INCREMENT=9 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+CREATE TABLE `Emotes` (
+ `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+ `name` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+ `emote_key` varchar(255) COLLATE utf8mb4_unicode_ci NOT NULL,
+ `animated` tinyint(4) NOT NULL DEFAULT '0',
+ `emote_id` bigint(20) unsigned NOT NULL DEFAULT '0',
+ `custom` tinyint(4) NOT NULL DEFAULT '1',
+ `tracking_disabled` tinyint(4) NOT NULL DEFAULT '1',
+ PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=18 DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
 SET FOREIGN_KEY_CHECKS=1;

--- a/src/OnePlusBot/Base/Core.cs
+++ b/src/OnePlusBot/Base/Core.cs
@@ -61,10 +61,19 @@ namespace OnePlusBot.Base
                 return Task.CompletedTask;
             };
 
+            Func<Task> emotePersister = null;
+            emotePersister = () => 
+            {
+                new EmoteHeatMapManager().SetupTimers().ContinueWith(t => Console.WriteLine(t.Exception), TaskContinuationOptions.OnlyOnFaulted);
+                bot.Ready -= emotePersister;
+                return Task.CompletedTask;
+            };
+
             bot.Ready += remindTimer;
             bot.Ready += muteTimer;
             bot.Ready += warnDecayTimer;
             bot.Ready += expPersister;
+            bot.Ready += emotePersister;
            
 
             if(Global.Token == string.Empty)

--- a/src/OnePlusBot/Base/EmoteHeatMapManager.cs
+++ b/src/OnePlusBot/Base/EmoteHeatMapManager.cs
@@ -1,0 +1,103 @@
+using Discord;
+using Discord.Rest;
+using System;
+using System.Threading.Tasks;
+using System.Linq;
+using OnePlusBot.Data.Models;
+using OnePlusBot.Data;
+using Discord.Commands;
+using Microsoft.EntityFrameworkCore;
+using Discord.WebSocket;
+using OnePlusBot.Base.Errors;
+using System.Collections.Generic;
+
+namespace OnePlusBot.Base
+{
+  public class EmoteHeatMapManager 
+  {
+
+    /// <summary>
+    /// Starts the timer to be executed at :30 of every minute to be done for the past minute
+    /// </summary>
+    public async Task<RuntimeResult> SetupTimers()
+    {
+      TimeSpan sinceMidnight = DateTime.Now.TimeOfDay;
+      TimeSpan nextMinute = TimeSpan.FromMinutes(Math.Ceiling(sinceMidnight.TotalMinutes));
+      TimeSpan timeSpanToDelay = (nextMinute - sinceMidnight);
+      // dont trigger exactly on the zero second, but on the :30 second and do the minute before
+      int secondsToDelay = (int) timeSpanToDelay.TotalSeconds + 30;
+      await Task.Delay(secondsToDelay * 1000);
+      await PersistEmotes();
+      System.Timers.Timer timer = new System.Timers.Timer(1000 * 60 * 1);
+      timer.Elapsed += new System.Timers.ElapsedEventHandler(TriggerPersitence);
+      timer.Enabled = true;
+      return CustomResult.FromSuccess();
+    }
+
+    /// <summary>
+    /// Executor for the persistence
+    /// </summary>
+    public async void TriggerPersitence(object sender, System.Timers.ElapsedEventArgs e)
+    {
+      await PersistEmotes();
+    }  
+
+    /// <summary>
+    /// Goes over the past minutes, and stores the used emotes in the heatmap. This removes the old entires from the runtime.
+    /// </summary>
+    /// <returns></returns>
+    public async Task PersistEmotes()
+    {
+      using(var db = new Database())
+      {
+        var minuteToPersist = (long) DateTime.Now.Subtract(DateTime.MinValue).TotalMinutes - 1;
+        Console.WriteLine($"Persisting emotes for minute {minuteToPersist} + {DateTime.Now}");
+        // if for some reason the elements were not persistet in the past rounds
+        // they will in the future, and because they are removed afterwards, this means that there *should* not be anything done twice
+        var minutesInThePast = Global.RuntimeEmotes.Keys.Where(minute => minute <= minuteToPersist);
+        List<long> toRemove = new List<long>();
+        if(minutesInThePast.Any())
+        {
+          foreach(var processedMinute in minutesInThePast)
+          {
+            StoreEmotesForMinute(Global.RuntimeEmotes[processedMinute], db);
+            toRemove.Add(processedMinute);
+          }
+        }
+        foreach(var minuteToRemove in toRemove)
+        {
+          Global.RuntimeEmotes.TryRemove(minuteToRemove, out _);
+        }
+        db.SaveChanges();
+      }
+    }
+
+    /// <summary>
+    /// Stores the given used emotes in the database
+    /// </summary>
+    /// <param name="emotesToUpdate">List of emoteId/usageCount pairs to be stored</param>
+    /// <param name="db">Database context</param>
+    public void StoreEmotesForMinute(List<KeyValuePair<uint, uint>> emotesToUpdate, Database db)
+    {
+      var updateDate = DateTime.Now;
+      foreach(var emotePair in emotesToUpdate)
+      {
+        var emote = db.EmoteHeatMap.Where(e => e.EmoteReference.ID == emotePair.Key && e.UpdateDate.Date == updateDate.Date);
+        if(emote.Any())
+        {
+          var emoteToChange = emote.First();
+          emoteToChange.UsageCount += emotePair.Value;
+        }
+        else
+        {
+          var emoteToChange = new EmoteHeatMap();
+          emoteToChange.Emote = emotePair.Key;
+          emoteToChange.UsageCount = emotePair.Value;
+          emoteToChange.UpdateDate = DateTime.Now;
+          db.EmoteHeatMap.Add(emoteToChange);
+        }
+      }
+      db.SaveChanges();
+    }
+  }
+}

--- a/src/OnePlusBot/Base/EmoteHeatMapManager.cs
+++ b/src/OnePlusBot/Base/EmoteHeatMapManager.cs
@@ -52,7 +52,7 @@ namespace OnePlusBot.Base
       {
         var minuteToPersist = (long) DateTime.Now.Subtract(DateTime.MinValue).TotalMinutes - 1;
         Console.WriteLine($"Persisting emotes for minute {minuteToPersist} + {DateTime.Now}");
-        // if for some reason the elements were not persistet in the past rounds
+        // if for some reason the elements were not persisted in the past rounds
         // they will in the future, and because they are removed afterwards, this means that there *should* not be anything done twice
         var minutesInThePast = Global.RuntimeEmotes.Keys.Where(minute => minute <= minuteToPersist);
         List<long> toRemove = new List<long>();

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -781,7 +781,11 @@ namespace OnePlusBot.Base
           {
             return;
           }
+          var minute = (long) DateTime.Now.Subtract(DateTime.MinValue).TotalMinutes;
           var emoteList = emoteTags.Select(t => (Emote)t.Value);
+          var exists = Global.RuntimeEmotes.ContainsKey(minute);
+          List<KeyValuePair<uint, uint>> usedEmotes = new List<KeyValuePair<uint, uint>>();
+          Global.RuntimeEmotes.TryGetValue(minute, out usedEmotes);
           foreach(var uncastEmote in emoteList) 
           {
             if(uncastEmote is Emote) 
@@ -791,18 +795,16 @@ namespace OnePlusBot.Base
               if(emotesFromServer.Any()) 
               {
                 var dbEmote = emotesFromServer.First();
-                var minute = (long) DateTime.Now.Subtract(DateTime.MinValue).TotalMinutes;
-                var exists = Global.RuntimeEmotes.ContainsKey(minute);
                 if(!exists)
                 {
                   var element = new List<KeyValuePair<uint, uint>>();
                   element.Add(new KeyValuePair<uint, uint>(dbEmote.Value.ID, 1));
                   Global.RuntimeEmotes.TryAdd(minute, element);
+                  exists = true;
+                  usedEmotes = element;
                 }
                 else
                 {
-                  List<KeyValuePair<uint, uint>> usedEmotes = new List<KeyValuePair<uint, uint>>();
-                  Global.RuntimeEmotes.TryGetValue(minute, out usedEmotes);
                   var existingEmoteLinq = usedEmotes.Where(tp => tp.Key == dbEmote.Value.ID);
                   if(existingEmoteLinq.Any()) 
                   {

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -791,7 +791,7 @@ namespace OnePlusBot.Base
             if(uncastEmote is Emote) 
             {
               Emote emote = uncastEmote as Emote;
-              var emotesFromServer = Global.Emotes.Where(e => e.Value.EmoteId == emote.Id);
+              var emotesFromServer = Global.TrackedEmotes.Where(e => e.Value.EmoteId == emote.Id);
               if(emotesFromServer.Any()) 
               {
                 var dbEmote = emotesFromServer.First();

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -53,6 +53,8 @@ namespace OnePlusBot.Base
 
         public static ConcurrentDictionary<long, List<ulong>> RuntimeExp { get; set; }
 
+        public static ConcurrentDictionary<long, List<KeyValuePair<uint, uint>>> RuntimeEmotes { get; set; }
+
         public static Dictionary<string, StoredEmote> Emotes { get; set; }
 
         public static bool XPGainDisabled { get; set; }
@@ -113,6 +115,7 @@ namespace OnePlusBot.Base
             ModMailThreads = new List<ModMailThread>();
             ReportedProfanities = new List<UsedProfanity>();
             RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
+            RuntimeEmotes = new ConcurrentDictionary<long, List<KeyValuePair<uint, uint>>>();
             Emotes = new Dictionary<string, StoredEmote>();
             Commands = new  List<Command>();
             UserNameNotifications = new Dictionary<ulong, ulong>();

--- a/src/OnePlusBot/Base/Global.cs
+++ b/src/OnePlusBot/Base/Global.cs
@@ -56,6 +56,7 @@ namespace OnePlusBot.Base
         public static ConcurrentDictionary<long, List<KeyValuePair<uint, uint>>> RuntimeEmotes { get; set; }
 
         public static Dictionary<string, StoredEmote> Emotes { get; set; }
+        public static Dictionary<string, StoredEmote> TrackedEmotes { get; set; }
 
         public static bool XPGainDisabled { get; set; }
 
@@ -117,6 +118,7 @@ namespace OnePlusBot.Base
             RuntimeExp = new ConcurrentDictionary<long, List<ulong>>();
             RuntimeEmotes = new ConcurrentDictionary<long, List<KeyValuePair<uint, uint>>>();
             Emotes = new Dictionary<string, StoredEmote>();
+            TrackedEmotes = new Dictionary<string, StoredEmote>();
             Commands = new  List<Command>();
             UserNameNotifications = new Dictionary<ulong, ulong>();
             LoadGlobal();
@@ -199,6 +201,15 @@ namespace OnePlusBot.Base
                     foreach(var post in db.Emotes)
                     {
                       Emotes.Add(post.Key, post);
+                    }
+                }
+
+                TrackedEmotes.Clear();
+                if(db.Emotes.Any())
+                {
+                    foreach(var post in db.Emotes.Where(e => !e.TrackingDisabled))
+                    {
+                      TrackedEmotes.Add(post.Key, post);
                     }
                 }
 

--- a/src/OnePlusBot/Base/ModMailEmbedHandler.cs
+++ b/src/OnePlusBot/Base/ModMailEmbedHandler.cs
@@ -56,7 +56,7 @@ namespace OnePlusBot
         /// <returns><see cref="Discord.EmbedAuthorBuilder"> object representing the oneplus discord author</returns>
         public static EmbedAuthorBuilder GetOneplusAuthor()
         {
-            return new EmbedAuthorBuilder().WithIconUrl("https://a.kyot.me/ab-y.png").WithName("r/Oneplus Discord");
+            return new EmbedAuthorBuilder().WithIconUrl("https://a.kyot.me/ab-y.png").WithName("r/OnePlus Discord");
         }
 
         public static EmbedAuthorBuilder GetUserAuthor(SocketUser user)

--- a/src/OnePlusBot/Data/Database.cs
+++ b/src/OnePlusBot/Data/Database.cs
@@ -15,6 +15,8 @@ namespace OnePlusBot.Data
         public DbSet<AuthToken> AuthTokens { get; set; }
         public DbSet<PersistentData> PersistentData { get; set; }
 
+        public DbSet<EmoteHeatMap> EmoteHeatMap { get; set; }
+
         public DbSet<ProfanityCheck> ProfanityChecks { get; set; }
         public DbSet<ReferralCode> ReferralCodes { get; set; }
 

--- a/src/OnePlusBot/Data/Models/EmoteHeatMap.cs
+++ b/src/OnePlusBot/Data/Models/EmoteHeatMap.cs
@@ -1,0 +1,27 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace OnePlusBot.Data.Models
+{
+    [Table("EmoteHeatMap")]
+    public class EmoteHeatMap
+    {
+        [Column("id")]
+        [Key]
+        public uint Id { get; set; }
+
+        [Column("emote_id")]
+        public uint Emote { get; set; }
+
+        [Column("usage_date")]
+        public DateTime UpdateDate { get; set; }
+
+        [Column("usage_count")]
+        public uint UsageCount { get; set; }
+
+        [ForeignKey("Emote")]
+        public virtual StoredEmote EmoteReference { get; set; }
+
+    }
+}

--- a/src/OnePlusBot/Data/Models/StoredEmote.cs
+++ b/src/OnePlusBot/Data/Models/StoredEmote.cs
@@ -32,6 +32,9 @@ namespace OnePlusBot.Data.Models
         [Column("custom")]
         public bool Custom { get; set; }
 
+        [Column("tracking_disabled")]
+        public bool TrackingDisabled { get; set; }
+
         public virtual ICollection<ReactionRole> EmoteReaction { get; set; }
 
         public IEmote GetAsEmote()

--- a/src/OnePlusBot/Modules/Administration/BotConfig.cs
+++ b/src/OnePlusBot/Modules/Administration/BotConfig.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading.Tasks;
 using Discord.Commands;
 using OnePlusBot.Base;
@@ -122,7 +123,7 @@ namespace OnePlusBot.Modules.Administration
         /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
         [
             Command("setEmote"),
-            Summary("Creats the emote in the database."),
+            Summary("Creates the emote in the database."),
             RequireRole("staff")
         ]
         public async Task<RuntimeResult> CreateEmoteInDatabase(string name, [Remainder] string _)
@@ -161,6 +162,33 @@ namespace OnePlusBot.Modules.Administration
           return CustomResult.FromSuccess();
         }
        
+       /// <summary>
+        /// Sets the tracking status of the emote in the database.
+        /// </summary>
+        /// <returns><see ref="Discord.RuntimeResult"> containing the result of the command</returns>
+        [
+            Command("trackEmote"),
+            Summary("Sets the emote tracking status."),
+            RequireRole("staff")
+        ]
+        public async Task<RuntimeResult> SetTrackingStatus(string name, Boolean value)
+        {
+            using(var db = new Database())
+            {
+              var sameKey = db.Emotes.Where(e => e.Key == name);
+              if(sameKey.Any()) 
+              {
+                StoredEmote emoteToChange = sameKey.First();
+                emoteToChange.TrackingDisabled = value;
+                db.SaveChanges();
+                return CustomResult.FromSuccess();
+              }
+              else
+              {
+                return CustomResult.FromError("Emote not found.");
+              }
+          }
+        }
 
     }
 }

--- a/src/OnePlusBot/Modules/Administration/Moderation.cs
+++ b/src/OnePlusBot/Modules/Administration/Moderation.cs
@@ -810,7 +810,7 @@ namespace OnePlusBot.Modules.Administration
             {
               count++;
               var emoteUsed = emoteUsedQuery.First();
-              currentEmbedBuilder.AddField(emoteUsed.GetAsEmote().ToString(), emoteStat.SUM);
+              currentEmbedBuilder.AddField(emoteUsed.GetAsEmote().ToString(), emoteStat.SUM, true);
               if(((count % EmbedBuilder.MaxFieldCount) == 0) && emoteStat != emoteStats.Last())
               {
                 embedsToPost.Add(currentEmbedBuilder.Build());

--- a/src/OnePlusBot/Modules/Administration/Moderation.cs
+++ b/src/OnePlusBot/Modules/Administration/Moderation.cs
@@ -13,7 +13,6 @@ using System.Linq;
 using Discord.WebSocket;
 using Discord.Net;
 using System.Collections.Generic;
-using OnePlusBot.Base.Errors;
 
 namespace OnePlusBot.Modules.Administration
 {
@@ -769,6 +768,66 @@ namespace OnePlusBot.Modules.Administration
           await Task.Delay(200);
         }
         return CustomResult.FromIgnored();
+      }
+
+      [
+        Command("emoteStats"),
+        Summary("Returns the tracked emote statistics. If no parameter is given, everything is returned."),
+        RequireRole("staff")
+      ]
+      public async Task<RuntimeResult> ShowEmoteStats([Optional] string range)
+      {
+        TimeSpan fromWhere;
+        DateTime startDate;
+        if(range != null)
+        {
+          fromWhere = Extensions.GetTimeSpanFromString(range);
+          startDate = DateTime.Now - fromWhere;
+        }
+        else
+        {
+          startDate = DateTime.MinValue;
+        }
+
+        var currentEmbedBuilder = new EmbedBuilder();
+        var embedsToPost = new List<Embed>();
+        using(var db = new Database())
+        {
+          var emoteStats = db.EmoteHeatMap
+          .Where(e => e.UpdateDate.Date > startDate.Date)
+          .GroupBy(e => e.Emote)
+          .Select(g => new
+                    {
+                      g.Key,
+                      SUM = g.Sum(s => s.UsageCount)
+                    })
+          .OrderByDescending(e => e.SUM);
+          var count = 0;
+          foreach(var emoteStat in emoteStats)
+          {
+            var emoteUsedQuery = db.Emotes.Where(e => e.ID == emoteStat.Key);
+            if(emoteUsedQuery.Any())
+            {
+              count++;
+              var emoteUsed = emoteUsedQuery.First();
+              currentEmbedBuilder.AddField(emoteUsed.GetAsEmote().ToString(), emoteStat.SUM);
+              if(((count % EmbedBuilder.MaxFieldCount) == 0) && emoteStat != emoteStats.Last())
+              {
+                embedsToPost.Add(currentEmbedBuilder.Build());
+                currentEmbedBuilder = new EmbedBuilder();
+                var currentPage = count / EmbedBuilder.MaxFieldCount + 1;
+                currentEmbedBuilder.WithFooter(new EmbedFooterBuilder().WithText($"Page {currentPage}"));
+              }
+            }
+          }
+        }
+        embedsToPost.Add(currentEmbedBuilder.Build());
+        foreach(var embed in embedsToPost)
+        {
+          await Context.Channel.SendMessageAsync(embed: embed);
+          await Task.Delay(500);
+        }
+        return CustomResult.FromSuccess();
       }
 
     }


### PR DESCRIPTION
Added the ability to track the usage of defined emotes to evaluate their usefulness. 
Emotes need to be defined by `setEmote name :emote:` (this also introduces the ability to change the emotes which are used internally by the bot, for example `SUCCESS`). 
If an emote is added this way, it is tracked by default, and this can be changed by the `trackEmote emoteName true|false` command. Both of these commands need a `reloadDb` for their changes to become active.
There exists a `emoteStats <optional timerange>` for which you receive the emote statistics for the tracked emotes for the given time period. If no time period is provided the whole statistic is printed.