### PR TITLE
Edit message regex to add discord.com

### DIFF
--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -23,7 +23,7 @@ namespace OnePlusBot.Base
         private readonly CommandService _commands;
         private readonly IServiceProvider _services;
 
-        private static Regex messageRegex = new Regex("(https://(?:(?:canary|ptb).)?discordapp.com/channels/(\\d+)/(\\d+)/(\\d+))+", RegexOptions.Singleline | RegexOptions.Compiled);
+        private static Regex messageRegex = new Regex("(https://(?:(?:canary|ptb).)?(?:discord|discordapp).com/channels/(\\d+)/(\\d+)/(\\d+))+", RegexOptions.Singleline | RegexOptions.Compiled);
 
         public CommandHandler(DiscordSocketClient bot, CommandService commands, IServiceProvider services)
         {


### PR DESCRIPTION
After changing its brand identity on [Twitter](https://twitter.com/discord) and other social networks, Discord might now [migrate](https://i.imgur.com/Taq3v8W.png) from [discordapp.com](https://discordapp.com) to [discord.com](https://discord.com) domain.
This change edit message regex to add support for it while maintaining backward compatibility with discordapp.com

