### PR TITLE
fixes #272, allowing image links to be posted in the embed as an image

### DIFF
--- a/src/OnePlusBot/Helpers/Extensions.cs
+++ b/src/OnePlusBot/Helpers/Extensions.cs
@@ -119,21 +119,33 @@ namespace OnePlusBot.Helpers
             foreach(var embed in message.Embeds)
             {
               // only support rich emebds for now
-              if(embed.Type != EmbedType.Rich) 
+              if(embed.Type == EmbedType.Rich)
               {
-                continue; 
+                stringBuilder.Append($" Embed \n");
+                if(embed.Title != string.Empty && embed.Title != null)
+                {
+                  stringBuilder.Append($"**{embed.Title}** \n");
+                }
+                stringBuilder.Append($"{embed.Description} \n");
+                foreach(var field in embed.Fields)
+                {
+                  stringBuilder.Append($" *{field.Name}*: {field.Value} \n");
+                }
               }
 
-              stringBuilder.Append($" Embed \n");
-              if(embed.Title != string.Empty && embed.Title != null)
-              {
-                stringBuilder.Append($"**{embed.Title}** \n");
-              }
-              stringBuilder.Append($"{embed.Description} \n");
-              foreach(var field in embed.Fields)
-              {
-                stringBuilder.Append($" *{field.Name}*: {field.Value} \n");
-              }
+            }
+          }
+          var potentialImageEmbed = message.Embeds.Where(e => e.Type == EmbedType.Image);
+          if(potentialImageEmbed.Any())
+          {
+            builder.WithImageUrl(potentialImageEmbed.First().Url);
+            if(message.Attachments.Count() > 0)
+            {
+              builder.WithThumbnailUrl(message.Attachments.First().ProxyUrl);
+            }
+            if(potentialImageEmbed.Count() > 1)
+            {
+              builder.AddField("Additional pictures", potentialImageEmbed.Count() -1);
             }
           }
           builder.WithDescription(stringBuilder.ToString());


### PR DESCRIPTION
Only images are supported, if multiple image links are present, the first one is taken, and the number of images is denoted in a separate field.

If an attachment and a image link is present, the attachment is moved to the thumbnail and the picture link is used as an image.