### PR TITLE
Added channel parameter for faq

### DIFF
--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -79,9 +79,9 @@ namespace OnePlusBot.Modules
         Summary("Answers frequently asked questions with a predetermined response."),
         CommandDisabledCheck
       ]
-      public async Task FAQAsync([Optional] [Remainder] string parameter)
+      public async Task FAQAsync([Optional] string parameter, [Optional] ISocketMessageChannel channel)
       {
-        var contextChannel = Context.Channel;
+        var contextChannel = channel ?? Context.Channel;
         if(parameter == null || parameter == string.Empty)
         {
             await PrintAvailableCommands(contextChannel);


### PR DESCRIPTION
The parameter is used as the context at which the availability and faq commands should be evaluated for. Per default its the current channel.