### PR TITLE
Added command to show an overview of faq commands

### DIFF
--- a/src/OnePlusBot/Modules/Channels/PostTarget.cs
+++ b/src/OnePlusBot/Modules/Channels/PostTarget.cs
@@ -1,5 +1,3 @@
-using System.Collections.Generic;
-using System;
 using System.Threading.Tasks;
 using Discord.Commands;
 using OnePlusBot.Base;

--- a/src/OnePlusBot/Modules/FAQ/FAQ.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQ.cs
@@ -1,0 +1,13 @@
+using Discord.Commands;
+using Discord.Addons.Interactive;
+
+namespace OnePlusBot.Modules.FAQ
+{
+    [
+      Summary("Module to configure and use the frequently asked questions (FAQ) functionality")
+    ]
+    public partial class FAQ : InteractiveBase<SocketCommandContext>
+    {
+        
+    }
+}

--- a/src/OnePlusBot/Modules/FAQ/FAQCommands.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQCommands.cs
@@ -1,16 +1,16 @@
-using System;
-using System.Text;
-using Discord.Commands;
 using Discord;
+using Discord.Commands;
+using OnePlusBot.Base;
+using System;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using Discord.Addons.Interactive;
-using OnePlusBot.Base;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using OnePlusBot.Data;
 using OnePlusBot.Data.Models;
 using Microsoft.EntityFrameworkCore;
-using System.Collections.Generic;    
-using System.Collections.ObjectModel;
 
 
 namespace OnePlusBot.Modules.FAQ
@@ -65,8 +65,17 @@ namespace OnePlusBot.Modules.FAQ
             return "no groups";
           }
           StringBuilder stringRepresentation = new StringBuilder();
-          stringRepresentation.Append("Groups:");
-          stringRepresentation.Append(string.Join(", ", channelGroups.Select(g => g.ChannelGroupReference.Name)));
+          foreach(FAQCommandChannel fch in channelGroups)
+          {
+            stringRepresentation.Append($"Group: {fch.ChannelGroupReference.Name} {Environment.NewLine}Channels: ");
+            foreach(ChannelInGroup ch in fch.ChannelGroupReference.Channels) {
+              stringRepresentation.Append($"<#{ch.ChannelId}> ");
+            }
+            if(fch.ChannelGroupReference.Channels.Count == 0) {
+              stringRepresentation.Append(" no channels.");
+            }
+            stringRepresentation.Append(Environment.NewLine);
+          }
 
           return stringRepresentation.ToString() != string.Empty ? stringRepresentation.ToString() : "no groups.";
         }

--- a/src/OnePlusBot/Modules/FAQ/FAQCommands.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQCommands.cs
@@ -62,20 +62,11 @@ namespace OnePlusBot.Modules.FAQ
         private string getChannelsAsMentions(ICollection<FAQCommandChannel> channelGroups)
         {
           if(channelGroups == null) {
-            return "no channels";
+            return "no groups";
           }
           StringBuilder stringRepresentation = new StringBuilder();
-          foreach(FAQCommandChannel fch in channelGroups)
-          {
-            stringRepresentation.Append($"Group: {fch.ChannelGroupReference.Name} {Environment.NewLine}Channels: ");
-            foreach(ChannelInGroup ch in fch.ChannelGroupReference.Channels) {
-              stringRepresentation.Append($"<#{ch.ChannelId}> ");
-            }
-            if(fch.ChannelGroupReference.Channels.Count == 0) {
-              stringRepresentation.Append(" no channels.");
-            }
-            stringRepresentation.Append(Environment.NewLine);
-          }
+          stringRepresentation.Append("Groups:");
+          stringRepresentation.Append(string.Join(", ", channelGroups.Select(g => g.ChannelGroupReference.Name)));
 
           return stringRepresentation.ToString() != string.Empty ? stringRepresentation.ToString() : "no groups.";
         }

--- a/src/OnePlusBot/Modules/FAQ/FAQCommands.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQCommands.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Text;
+using Discord.Commands;
+using Discord;
+using System.Linq;
+using System.Threading.Tasks;
+using Discord.Addons.Interactive;
+using OnePlusBot.Base;
+using OnePlusBot.Data;
+using OnePlusBot.Data.Models;
+using Microsoft.EntityFrameworkCore;
+using System.Collections.Generic;    
+using System.Collections.ObjectModel;
+
+
+namespace OnePlusBot.Modules.FAQ
+{
+    public partial class FAQ : InteractiveBase<SocketCommandContext>
+    {
+
+        [
+            Command("faqCommands"),
+            Summary("Lists the currently configured "),
+            RequireRole("staff"),
+            CommandDisabledCheck
+        ]
+        public async Task ListFAQCommands()
+        {
+          Collection<Embed> embedsToPost = new Collection<Embed>();
+          using(var db = new Database())
+          {
+            var currentEmbedBuilder = new EmbedBuilder();
+            currentEmbedBuilder.WithTitle("Available faq commands");
+            List<FAQCommand> commmands = db.FAQCommands.Include(c => c.CommandChannels)
+            .ThenInclude(cc => cc.ChannelGroupReference)
+            .ThenInclude(cgr => cgr.Channels)
+            .OrderBy(c => c.ID)
+            .ToList();
+            
+            var count = 0;
+            foreach(var command in commmands)
+            {
+              count++;
+              var channelMentions = getChannelsAsMentions(command.CommandChannels);
+              currentEmbedBuilder.AddField(command.Name, channelMentions, true);
+              if(((count % EmbedBuilder.MaxFieldCount) == 0) && command != commmands.Last())
+              {
+                embedsToPost.Add(currentEmbedBuilder.Build());
+                currentEmbedBuilder = new EmbedBuilder();
+                var currentPage = count / EmbedBuilder.MaxFieldCount + 1;
+                currentEmbedBuilder.WithFooter(new EmbedFooterBuilder().WithText($"Page {currentPage}"));
+              }  
+            }
+            embedsToPost.Add(currentEmbedBuilder.Build());
+          }
+          foreach (var embed in embedsToPost) {
+            await Context.Channel.SendMessageAsync(embed: embed);
+            await Task.Delay(200);
+          }
+        }
+
+        private string getChannelsAsMentions(ICollection<FAQCommandChannel> channelGroups)
+        {
+          if(channelGroups == null) {
+            return "no channels";
+          }
+          StringBuilder stringRepresentation = new StringBuilder();
+          foreach(FAQCommandChannel fch in channelGroups)
+          {
+            stringRepresentation.Append($"Group: {fch.ChannelGroupReference.Name} {Environment.NewLine}Channels: ");
+            foreach(ChannelInGroup ch in fch.ChannelGroupReference.Channels) {
+              stringRepresentation.Append($"<#{ch.ChannelId}> ");
+            }
+            if(fch.ChannelGroupReference.Channels.Count == 0) {
+              stringRepresentation.Append(" no channels.");
+            }
+            stringRepresentation.Append(Environment.NewLine);
+          }
+
+          return stringRepresentation.ToString() != string.Empty ? stringRepresentation.ToString() : "no groups.";
+        }
+    }
+}

--- a/src/OnePlusBot/Modules/FAQ/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQConfiguration.cs
@@ -1,5 +1,4 @@
 using System.Text;
-using System.Reflection.Metadata;
 using System;
 using Discord.Commands;
 using Discord;
@@ -14,12 +13,9 @@ using Microsoft.EntityFrameworkCore;
 using System.Collections.Generic;    
 
 
-namespace OnePlusBot.Modules
+namespace OnePlusBot.Modules.FAQ
 {
-    [
-      Summary("Module containing the command to configure the faq commands.")
-    ]
-    public class FAQConfiguration : InteractiveBase<SocketCommandContext>
+    public partial class FAQ : InteractiveBase<SocketCommandContext>
     {
 
         [

--- a/src/OnePlusBot/Modules/FAQ/FAQUsage.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQUsage.cs
@@ -1,0 +1,118 @@
+using Discord;
+using Discord.Commands;
+using OnePlusBot.Base;
+using System;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using OnePlusBot.Helpers;
+using Discord.WebSocket;
+using System.Runtime.InteropServices;
+using Discord.Addons.Interactive;
+
+namespace OnePlusBot.Modules.FAQ
+{
+
+  public partial class FAQ : InteractiveBase<SocketCommandContext>
+  {
+      [
+      Command("faq"),
+      Summary("Answers frequently asked questions with a predetermined response."),
+      CommandDisabledCheck
+    ]
+    public async Task FAQAsync([Optional] [Remainder] string parameter)
+    {
+      var contextChannel = Context.Channel;
+      if(parameter == null || parameter == string.Empty)
+      {
+          await PrintAvailableCommands(contextChannel);
+          return;
+      }
+      var commands = Global.FAQCommands;
+      parameter = parameter.Trim();
+      var appropriateCommand = commands.Where(m => 
+      {
+          bool usingAlias = Array.Exists(m.IndividualAliases(), alias => alias.Equals(parameter));
+          return (m.Name == parameter || usingAlias);
+      });
+      if(appropriateCommand.Any())
+      {
+        var matchingCommand = appropriateCommand.First();
+        if(matchingCommand.CommandChannels != null) 
+        {
+          var commandChannels = matchingCommand.CommandChannels.Where(cha => cha.ChannelGroupReference.Channels.Where(grp => grp.ChannelId == contextChannel.Id).FirstOrDefault() != null);
+          if(commandChannels.Any())
+          {
+            if(commandChannels.Count() > 1)
+            {
+              await Context.Channel.SendMessageAsync("Warning command have different responses for this channel");
+            }
+            foreach(var commandChannel in commandChannels){
+              var entries = commandChannels.First().CommandChannelEntries.OrderBy(entry => entry.Position);
+              if(entries.Any())
+              {
+                foreach(var entry in entries)
+                {
+                  if(!entry.IsEmbed)
+                  {
+                    await Context.Channel.SendMessageAsync(entry.Text);
+                  }
+                  else 
+                  {
+                    var embed = Extensions.FaqCommandEntryToBuilder(entry);
+                    await Context.Channel.SendMessageAsync(embed: embed.Build());
+                  }
+                  await Task.Delay(200);
+                }
+              } 
+              else
+              {
+                await Context.Channel.SendMessageAsync($"Channel has no posts configured for command {appropriateCommand.First().Name}.");
+              }
+            }
+          }
+          else
+          {
+            await PrintAvailableCommands(contextChannel);
+          }
+        }
+        else 
+        {
+          await Context.Channel.SendMessageAsync($"Channel has no entry configured for command {appropriateCommand.First().Name}.");
+        }
+      }
+      else 
+      {
+        await PrintAvailableCommands(contextChannel);
+      }
+    }
+    public async Task PrintAvailableCommands(ISocketMessageChannel contextChannel)
+    {
+      var commandsAvailable = Global.FAQCommandChannels.
+      Where(ch => ch.ChannelGroupReference.Channels.
+          Where(grp => grp.ChannelId == contextChannel.Id).
+          FirstOrDefault() != null)
+      .ToList();
+      if(commandsAvailable.Count() == 0)
+      {
+          await Context.Channel.SendMessageAsync("No entry available.");
+      } 
+      else
+      {
+        var stringBuilder = new StringBuilder(" ");
+        for(var index = 0; index < commandsAvailable.Count; index++)
+        {
+          var command = commandsAvailable[index];
+          stringBuilder.Append($"`{command.Command.Name}`");
+          if(index < commandsAvailable.Count -1 )
+          {
+              stringBuilder.Append(", ");
+          }
+        }
+        var embedBuilder = new EmbedBuilder().WithTitle("Available entries in this channel").WithDescription(stringBuilder.ToString());
+        
+        await Context.Channel.SendMessageAsync(embed: embedBuilder.Build());
+      }
+    }
+  }
+}

--- a/src/OnePlusBot/Modules/Support.cs
+++ b/src/OnePlusBot/Modules/Support.cs
@@ -116,14 +116,14 @@ namespace OnePlusBot.Modules
                     {
                       await Context.Channel.SendMessageAsync(entry.Text);
                     }
-                    else 
+                    else
                     {
                       var embed = Extensions.FaqCommandEntryToBuilder(entry);
                       await Context.Channel.SendMessageAsync(embed: embed.Build());
                     }
                     await Task.Delay(200);
                   }
-                } 
+                }
                 else
                 {
                   await Context.Channel.SendMessageAsync($"Channel has no posts configured for command {appropriateCommand.First().Name}.");
@@ -135,12 +135,12 @@ namespace OnePlusBot.Modules
               await PrintAvailableCommands(contextChannel);
             }
           }
-          else 
+          else
           {
             await Context.Channel.SendMessageAsync($"Channel has no entry configured for command {appropriateCommand.First().Name}.");
           }
         }
-        else 
+        else
         {
           await PrintAvailableCommands(contextChannel);
         }
@@ -155,7 +155,7 @@ namespace OnePlusBot.Modules
         if(commandsAvailable.Count() == 0)
         {
             await Context.Channel.SendMessageAsync("No entry available.");
-        } 
+        }
         else
         {
           var stringBuilder = new StringBuilder(" ");


### PR DESCRIPTION
This pull request adds a command to show the current faq configuration. The command is called `faqCommands`.
This includes a list of the commands currently configured, and the respective channel groups with their associated channels.