### PR TITLE
Modmail mute notification

### DIFF
--- a/src/OnePlusBot/Base/ModMailManager.cs
+++ b/src/OnePlusBot/Base/ModMailManager.cs
@@ -720,6 +720,24 @@ namespace OnePlusBot.Base
         muteNotificationBuilder.AddField("Disabled until", Extensions.FormatDateTime(until));
         await muteLogChannel.SendMessageAsync(embed: muteNotificationBuilder.Build());
     }
+
+    /// <summary>
+    /// Sends a notification to show that modmail has been enabled again for a user.
+    /// </summary>
+    /// <param name="enabledUser">The user for which modmail has been enabled again</param>
+    /// <param name="enablingUser">The user which executes the enabling command</param>
+    /// <returns></returns>
+    public async Task SendModmailUnmutedNotification(IUser enabledUser, IUser enablingUser) {
+        var bot = Global.Bot;
+        var guild = bot.GetGuild(Global.ServerID);
+
+        var muteLogChannel = guild.GetTextChannel(Global.PostTargets[PostTarget.MODMAIL_MUTE_LOG]);
+        var muteNotificationBuilder = new EmbedBuilder();
+        muteNotificationBuilder.WithTitle("Modmail has been enabled for user!");
+        muteNotificationBuilder.AddField("User", Extensions.FormatMentionDetailed(enabledUser));
+        muteNotificationBuilder.AddField("Enabled by", Extensions.FormatMentionDetailed(enablingUser));
+        await muteLogChannel.SendMessageAsync(embed: muteNotificationBuilder.Build());
+    }
     
   }
 }

--- a/src/OnePlusBot/Data/Models/PostTarget.cs
+++ b/src/OnePlusBot/Data/Models/PostTarget.cs
@@ -34,6 +34,7 @@ namespace OnePlusBot.Data.Models
         public static readonly string STARBOARD = "starboard";
         public static readonly string STARBOARD_LOG = "starboardLog";
         public static readonly string UNBAN_LOG = "unbanlog";
+        public static readonly string MODMAIL_MUTE_LOG = "modmailMuteLog";
         public static readonly string SUGGESTIONS = "suggestions";
         public static readonly string USERNAME_QUEUE = "usernamequeue";
         public static readonly string WARN_LOG = "warnlog";
@@ -51,7 +52,7 @@ namespace OnePlusBot.Data.Models
                                 MUTE_LOG, NEWS, PROFANITY_QUEUE, 
                                 STARBOARD, UNBAN_LOG, SUGGESTIONS, 
                                 USERNAME_QUEUE, WARN_LOG, LEAVE_LOG,
-                                INFO, FEEDBACK
+                                INFO, FEEDBACK, MODMAIL_MUTE_LOG
                               };
       
     }

--- a/src/OnePlusBot/Modules/Administration/Moderation.cs
+++ b/src/OnePlusBot/Modules/Administration/Moderation.cs
@@ -284,7 +284,7 @@ namespace OnePlusBot.Modules.Administration
           RequireRole("staff"),
           CommandDisabledCheck
       ]
-      public async Task<RuntimeResult> SetNicknameTo(IGuildUser user, [Optional]string newNickname)
+      public async Task<RuntimeResult> SetNicknameTo(IGuildUser user, [Optional] [Remainder] string newNickname)
       {
         await user.ModifyAsync((user) => user.Nickname = newNickname);
         return CustomResult.FromSuccess();

--- a/src/OnePlusBot/Modules/ModMail.cs
+++ b/src/OnePlusBot/Modules/ModMail.cs
@@ -215,6 +215,7 @@ namespace OnePlusBot.Modules
         public async Task<RuntimeResult> EnableModmailForUser(IGuildUser user)
         {
           new  ModMailManager().EnableModmailForUser(user);
+          await new ModMailManager().SendModmailUnmutedNotification(user, Context.User);
           await Task.CompletedTask;
           return CustomResult.FromSuccess();
         }

--- a/src/OnePlusBot/Modules/ModMail.cs
+++ b/src/OnePlusBot/Modules/ModMail.cs
@@ -157,53 +157,52 @@ namespace OnePlusBot.Modules
           return CustomResult.FromIgnored();
         }
 
+        /// <summary>
+        /// Disables modmail for the user the thread is about and closes the thread. This only works within a modmail thread
+        /// </summary>
+        /// <param name="duration">The duration for which the modmail functionality should be disabled for</param>
+        /// <param name="note">Optional note which should accompany the logging</param>
+        /// <returns></returns>
         [
           Command("disableThread", RunMode = RunMode.Async),
-          Summary("disables and closes the modmail thread for a certain time period. The user will be notified and he will be able to contact modmail after the period again."),
+          Summary("Disables and closes the modmail thread for a certain time period. The user will be notified and will be able to contact modmail after the period again."),
           RequireRole("staff"),
           RequireBotPermission(GuildPermission.ManageChannels),
           RequireModMailContext
         ]
-        public async Task<RuntimeResult> DisableCurrentThread(params string[] arguments)
+        public async Task<RuntimeResult> DisableCurrentThread(string duration, [Remainder] [Optional] string note)
         {
-          var durationStr = arguments[0];
-          string note;
-          if(arguments.Length > 1)
-          {
-            string[] noteParts = new string[arguments.Length -1];
-            Array.Copy(arguments, 1, noteParts, 0, arguments.Length - 1);
-            note = string.Join(" ", noteParts);
-          }
-          else
-          {
-            return CustomResult.FromError("You need to provide a note.");
-          }
-          TimeSpan mutedTime = Extensions.GetTimeSpanFromString(durationStr);
+          TimeSpan mutedTime = Extensions.GetTimeSpanFromString(duration);
           var until = DateTime.Now + mutedTime;
           var manager = new ModMailManager();
-          await manager.LogForDisablingAction(Context.Channel, note, until);
+          await manager.LogForDisablingAction(Context.Channel, note, until, Context.User);
           manager.DisableModMailForUserWithExistingThread(Context.Channel, until);
-
           return CustomResult.FromIgnored();
         }
 
+
+        /// <summary>
+        /// Disables modmail for a user outside of a thread. Does not require a note and sends a notification.
+        /// </summary>
+        /// <param name="user">User to disable modmail for</param>
+        /// <param name="duration">The duration to disable modmail for</param>
+        /// <returns></returns>
         [
           Command("disableModmail"),
           Summary("Disables modmail for a certain time period. The target user will be able to contact modmail after the time has been reached."),
           RequireRole("staff"),
           CommandDisabledCheck
         ]
-        public async Task<RuntimeResult> DisableModMailForUser(IGuildUser user,  params string[] arguments)
+        public async Task<RuntimeResult> DisableModMailForUser(IGuildUser user, [Remainder] string duration)
         {
-          if(arguments.Length < 1)
+          if(duration is null)
           {
-              return CustomResult.FromError("You need to provide a duration");
+            return CustomResult.FromError("You need to provide a duration.");
           }
-          var durationStr = arguments[0];
-          TimeSpan mutedTime = Extensions.GetTimeSpanFromString(durationStr);
+          TimeSpan mutedTime = Extensions.GetTimeSpanFromString(duration);
           var until = DateTime.Now + mutedTime;
           new ModMailManager().DisableModmailForUser(user, until);
-          await Task.CompletedTask;
+          await new ModMailManager().SendModmailMuteNofication(user, Context.User, until);
           return CustomResult.FromSuccess();
         }
 


### PR DESCRIPTION
Added logging notification when muting modmail for a user and requires a separate post target.
This notification is also sent when modmail is enabled again.
This also fixes the missing remainder for setnickname and a bug related to disabling modmail.