### PR TITLE
changed pagination for configuration steps

### DIFF
--- a/src/OnePlusBot/Modules/FAQ/FAQConfiguration.cs
+++ b/src/OnePlusBot/Modules/FAQ/FAQConfiguration.cs
@@ -42,8 +42,9 @@ namespace OnePlusBot.Modules.FAQ
             var embedTextStep = new ConfigurationStep("Please enter the text you want to give your embed", Interactive, Context, ConfigurationStep.StepType.Text, embedStep);
             var embedColorStep = new ConfigurationStep("Please choose a color you want to use for the embed", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
             var authorStep = new ConfigurationStep("Do you want to be marked as author? (✅ yes, ❌ no)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
-            var deletionStep = new ConfigurationStep("React to the command in the channel you want to remove (❌ go back, ◀ seek backward, ▶ seek forward)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
-            var commandDeletionStep = new ConfigurationStep("React to the command you want to completely remove (❌ go back, ◀ seek backward, ▶ seek forward)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var deletionStep = new ConfigurationStep("React to the command in the channel you want to remove (❌ go back, 📇 select page or ◀ seek backward, ▶ seek forward)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
+            var skipStep = new ConfigurationStep("Which page do you want to jump to? Enter the number alone.", Interactive, Context, ConfigurationStep.StepType.Text, deletionStep);
+            var commandDeletionStep = new ConfigurationStep("React to the command you want to completely remove (❌ go back, 📇 select page or ◀ seek backward, ▶ seek forward)", Interactive, Context, ConfigurationStep.StepType.Reaction, null);
             var chooseExistingEntryStep = new ConfigurationStep("Which post do you want to use?", Interactive, Context, ConfigurationStep.StepType.Text, addStep);
 
             var existingCommands = Global.FAQCommands.ToList();


### PR DESCRIPTION
if there are >= 3 pages available, the pagination with action uses a different pagination:
There is a separate reaction which opens a prompt for you to select a page.
If there are less pages the old pagination is available.
In general: The current page and the total amount of pages is displaced, beware that this only reflects the cached count, so it might need a cache reload to be updated in case of deletions.