### PR TITLE
made some roles immune from checks and suggest supports attachments

### DIFF
--- a/src/OnePlusBot/Base/CommandDisabledCheck.cs
+++ b/src/OnePlusBot/Base/CommandDisabledCheck.cs
@@ -36,6 +36,12 @@ namespace OnePlusBot.Base
             }
             else 
             {
+              var guild = Global.Bot.GetGuild(Global.ServerID);
+              var guildUser = guild.GetUser(context.User.Id);
+              if(guildUser != null && guildUser.Roles.Where(ro => ro.Id == Global.Roles["staff"]).Any())
+              {
+                return Task.FromResult(PreconditionResult.FromSuccess());
+              }
               return Task.FromResult(PreconditionResult.FromError("Command disabled in this channel"));
             }
         }

--- a/src/OnePlusBot/Base/EventHandlers.cs
+++ b/src/OnePlusBot/Base/EventHandlers.cs
@@ -898,6 +898,13 @@ namespace OnePlusBot.Base
           }
         }
 
+        private static bool isFromImmuneUser(SocketMessage message) 
+        {
+          var guild = Global.Bot.GetGuild(Global.ServerID);
+          var guildUser = guild.GetUser(message.Author.Id);
+          return guildUser != null && guildUser.Roles.Where(ro => ro.Id == Global.Roles["staff"]).Any();
+        }
+
         /// <summary>
         /// Checks if the message content contains a link to message and if so (and the channel is in a guild) embeds the message in the context channel
         /// </summary>
@@ -947,13 +954,14 @@ namespace OnePlusBot.Base
 
         private static async Task OnMessageReceived(SocketMessage message)
         {
-            if (ViolatesRule(message))
+            bool immuneAuthor = isFromImmuneUser(message);
+            if (ViolatesRule(message) && !immuneAuthor)
             {
                 await message.DeleteAsync();
             }
 
             var channel = Extensions.GetChannelById(message.Channel.Id);
-            if(channel != null)
+            if(channel != null && !immuneAuthor)
             {
                 if(!channel.ProfanityExempt())
                 {

--- a/src/OnePlusBot/Modules/Utility/Server.cs
+++ b/src/OnePlusBot/Modules/Utility/Server.cs
@@ -33,11 +33,18 @@ namespace OnePlusBot.Modules.Utility
 
             if (suggestion.Contains("@everyone") || suggestion.Contains("@here"))
                 return;
-
-            var oldmessage = await suggestionsChannel.EmbedAsync(new EmbedBuilder()
+              
+            var embed = new EmbedBuilder()
                 .WithColor(9896005)
                 .WithDescription(suggestion)
-                .WithFooter(user.ToString()));
+                .WithFooter(user.ToString());
+              
+            if(Context.Message.Attachments.Count > 0) 
+            {
+              embed.WithImageUrl(Context.Message.Attachments.ToList()[0].ProxyUrl);
+            }
+
+            var oldmessage = await suggestionsChannel.EmbedAsync(embed);
 
             await oldmessage.AddReactionsAsync(new IEmote[]
             {


### PR DESCRIPTION
The immune check is based on the pre-configured staff role. This immune check has been added to the command disabled checks, profanities check and invite check.
The attachment for the suggest embed is directly taken from the message and optional.