### PR TITLE
dont delete message on suggest

### DIFF
--- a/src/OnePlusBot/Modules/Utility/Server.cs
+++ b/src/OnePlusBot/Modules/Utility/Server.cs
@@ -52,7 +52,7 @@ namespace OnePlusBot.Modules.Utility
               StoredEmote.GetEmote(Global.OnePlusEmote.OP_YES)
             });
             
-            await Context.Message.DeleteAsync();
+
         }
 
         [


### PR DESCRIPTION
If the message contains an attachment, it would be deleted as well, leading to a 404. So dont delete it at all.